### PR TITLE
perf(ac-daemon): cache JACK port lists (recover stranded #38)

### DIFF
--- a/ac-rs/crates/ac-daemon/src/handlers/admin.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/admin.rs
@@ -5,10 +5,9 @@ use serde_json::{json, Value};
 
 use ac_core::calibration::Calibration;
 
-use crate::audio::make_engine;
 use crate::server::ServerState;
 
-use super::read_dmm_vrms;
+use super::{cached_capture_ports, cached_playback_ports, read_dmm_vrms, refresh_port_cache};
 
 pub fn status(state: &ServerState) -> Value {
     let workers = state.workers.lock().unwrap();
@@ -49,10 +48,11 @@ pub fn stop(state: &ServerState, cmd: &Value) -> Value {
 }
 
 pub fn devices(state: &ServerState) -> Value {
-    let cfg = state.cfg.lock().unwrap().clone();
-    let engine = make_engine(state.fake_audio);
-    let playback = engine.playback_ports();
-    let capture  = engine.capture_ports();
+    // `devices` is the documented hardware rescan trigger — always refresh.
+    refresh_port_cache(state);
+    let cfg      = state.cfg.lock().unwrap().clone();
+    let playback = cached_playback_ports(state);
+    let capture  = cached_capture_ports(state);
     json!({
         "ok":                true,
         "playback":          playback,

--- a/ac-rs/crates/ac-daemon/src/handlers/audio.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/audio.rs
@@ -21,7 +21,7 @@ pub fn generate(state: &ServerState, cmd: &Value) -> Value {
     let level_dbfs = cmd.get("level_dbfs").and_then(Value::as_f64).unwrap_or(-10.0);
     let cfg        = state.cfg.lock().unwrap().clone();
 
-    let out_port = vec![resolve_output(&cfg, state.fake_audio)];
+    let out_port = vec![resolve_output(&cfg, state)];
 
     let pub_tx   = state.pub_tx.clone();
     let fake     = state.fake_audio;
@@ -47,7 +47,7 @@ pub fn generate(state: &ServerState, cmd: &Value) -> Value {
         workers.insert("generate".to_string(), worker);
     }
 
-    let resolved = resolve_output(&cfg, state.fake_audio);
+    let resolved = resolve_output(&cfg, state);
     json!({"ok": true, "out_ports": [resolved]})
 }
 
@@ -56,7 +56,7 @@ pub fn generate_pink(state: &ServerState, cmd: &Value) -> Value {
     let level_dbfs = cmd.get("level_dbfs").and_then(Value::as_f64).unwrap_or(-10.0);
     let cfg        = state.cfg.lock().unwrap().clone();
 
-    let out_port = vec![resolve_output(&cfg, state.fake_audio)];
+    let out_port = vec![resolve_output(&cfg, state)];
 
     let pub_tx = state.pub_tx.clone();
     let fake   = state.fake_audio;
@@ -82,7 +82,7 @@ pub fn generate_pink(state: &ServerState, cmd: &Value) -> Value {
         workers.insert("generate_pink".to_string(), worker);
     }
 
-    let resolved = resolve_output(&cfg, state.fake_audio);
+    let resolved = resolve_output(&cfg, state);
     json!({"ok": true, "out_ports": [resolved]})
 }
 
@@ -96,7 +96,7 @@ pub fn sweep_level(state: &ServerState, cmd: &Value) -> Value {
     let stop_dbfs  = cmd.get("stop_dbfs") .and_then(Value::as_f64).unwrap_or(0.0);
     let duration   = cmd.get("duration")  .and_then(Value::as_f64).unwrap_or(1.0);
     let cfg        = state.cfg.lock().unwrap().clone();
-    let out_port   = resolve_output(&cfg, state.fake_audio);
+    let out_port   = resolve_output(&cfg, state);
     let out_port_reply = out_port.clone();
 
     let pub_tx = state.pub_tx.clone();
@@ -138,7 +138,7 @@ pub fn sweep_frequency(state: &ServerState, cmd: &Value) -> Value {
     let level_dbfs = cmd.get("level_dbfs").and_then(Value::as_f64).unwrap_or(-10.0);
     let duration   = cmd.get("duration")  .and_then(Value::as_f64).unwrap_or(1.0);
     let cfg        = state.cfg.lock().unwrap().clone();
-    let out_port   = resolve_output(&cfg, state.fake_audio);
+    let out_port   = resolve_output(&cfg, state);
     let out_port_reply = out_port.clone();
     let amplitude  = ac_core::generator::dbfs_to_amplitude(level_dbfs);
 
@@ -182,8 +182,8 @@ pub fn plot(state: &ServerState, cmd: &Value) -> Value {
     let duration   = cmd.get("duration")  .and_then(Value::as_f64).unwrap_or(1.0);
     let cfg        = state.cfg.lock().unwrap().clone();
 
-    let out_port = resolve_output(&cfg, state.fake_audio);
-    let in_port  = resolve_input(&cfg, state.fake_audio);
+    let out_port = resolve_output(&cfg, state);
+    let in_port  = resolve_input(&cfg, state);
     let out_port_reply = out_port.clone();
     let in_port_reply  = in_port.clone();
 
@@ -250,8 +250,8 @@ pub fn plot_level(state: &ServerState, cmd: &Value) -> Value {
     let duration   = cmd.get("duration")  .and_then(Value::as_f64).unwrap_or(1.0);
     let cfg        = state.cfg.lock().unwrap().clone();
 
-    let out_port = resolve_output(&cfg, state.fake_audio);
-    let in_port  = resolve_input(&cfg, state.fake_audio);
+    let out_port = resolve_output(&cfg, state);
+    let in_port  = resolve_input(&cfg, state);
     let out_port_reply = out_port.clone();
     let in_port_reply  = in_port.clone();
 
@@ -314,7 +314,7 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
     let freq_hz  = cmd.get("freq_hz") .and_then(Value::as_f64).unwrap_or(1000.0);
     let interval = cmd.get("interval").and_then(Value::as_f64).unwrap_or(0.2);
     let cfg      = state.cfg.lock().unwrap().clone();
-    let in_port  = resolve_input(&cfg, state.fake_audio);
+    let in_port  = resolve_input(&cfg, state);
     let in_port_reply = in_port.clone();
 
     let pub_tx = state.pub_tx.clone();

--- a/ac-rs/crates/ac-daemon/src/handlers/calibrate.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/calibrate.rs
@@ -26,7 +26,7 @@ pub fn calibrate(state: &ServerState, cmd: &Value) -> Value {
 
     let pub_tx       = state.pub_tx.clone();
     let fake         = state.fake_audio;
-    let out_port     = resolve_output(&cfg, state.fake_audio);
+    let out_port     = resolve_output(&cfg, state);
     let cal_reply_tx = state.cal_reply_tx.clone();
 
     let worker = spawn_worker(state, "calibrate", move |stop| {

--- a/ac-rs/crates/ac-daemon/src/handlers/mod.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/mod.rs
@@ -104,49 +104,81 @@ where
 }
 
 // ---------------------------------------------------------------------------
+// Port cache (Issue #30)
+//
+// JACK port queries open a fresh `ac-daemon-probe` client every call, which
+// costs a full activate/deactivate round-trip (~50–150 ms on a busy jackd).
+// Before this cache, a single `test_hardware` invocation would spin up 4+
+// probe clients just to resolve sticky port names for routing. The cache is
+// populated lazily on first read and refreshed whenever the user issues
+// `devices` (which is the documented way to "rescan hardware").
+// ---------------------------------------------------------------------------
+
+pub(super) fn cached_playback_ports(state: &ServerState) -> Vec<String> {
+    let mut guard = state.playback_ports_cache.lock().unwrap();
+    if guard.is_none() {
+        let eng = make_engine(state.fake_audio);
+        *guard = Some(eng.playback_ports());
+    }
+    guard.clone().unwrap_or_default()
+}
+
+pub(super) fn cached_capture_ports(state: &ServerState) -> Vec<String> {
+    let mut guard = state.capture_ports_cache.lock().unwrap();
+    if guard.is_none() {
+        let eng = make_engine(state.fake_audio);
+        *guard = Some(eng.capture_ports());
+    }
+    guard.clone().unwrap_or_default()
+}
+
+/// Force a rescan on the next port query. Called by `devices`.
+pub(super) fn refresh_port_cache(state: &ServerState) {
+    let eng = make_engine(state.fake_audio);
+    *state.playback_ports_cache.lock().unwrap() = Some(eng.playback_ports());
+    *state.capture_ports_cache .lock().unwrap() = Some(eng.capture_ports());
+}
+
+// ---------------------------------------------------------------------------
 // Port resolution
 // ---------------------------------------------------------------------------
 
 /// Resolve output port: config sticky name, or fall back to channel index in engine list.
-pub(super) fn resolve_output(cfg: &Config, fake_audio: bool) -> String {
+pub(super) fn resolve_output(cfg: &Config, state: &ServerState) -> String {
     if let Some(p) = &cfg.output_port {
         return p.clone();
     }
-    let eng = make_engine(fake_audio);
-    let ports = eng.playback_ports();
+    let ports = cached_playback_ports(state);
     let ch = cfg.output_channel as usize;
     ports.get(ch).cloned().unwrap_or_else(|| "system:playback_1".to_string())
 }
 
 /// Resolve input port: config sticky name, or fall back to channel index in engine list.
-pub(super) fn resolve_input(cfg: &Config, fake_audio: bool) -> String {
+pub(super) fn resolve_input(cfg: &Config, state: &ServerState) -> String {
     if let Some(p) = &cfg.input_port {
         return p.clone();
     }
-    let eng = make_engine(fake_audio);
-    let ports = eng.capture_ports();
+    let ports = cached_capture_ports(state);
     let ch = cfg.input_channel as usize;
     ports.get(ch).cloned().unwrap_or_else(|| "system:capture_1".to_string())
 }
 
-pub(super) fn resolve_ref_input(cfg: &Config, fake_audio: bool) -> Option<String> {
+pub(super) fn resolve_ref_input(cfg: &Config, state: &ServerState) -> Option<String> {
     let ch = cfg.reference_channel? as usize;
     if let Some(p) = &cfg.reference_port {
         return Some(p.clone());
     }
-    let eng = make_engine(fake_audio);
-    eng.capture_ports().get(ch).cloned()
+    cached_capture_ports(state).get(ch).cloned()
 }
 
-pub(super) fn resolve_ref_output(cfg: &Config, fake_audio: bool) -> String {
+pub(super) fn resolve_ref_output(cfg: &Config, state: &ServerState) -> String {
     if let Some(ch) = cfg.reference_channel {
-        let eng = make_engine(fake_audio);
-        let ports = eng.playback_ports();
+        let ports = cached_playback_ports(state);
         if let Some(p) = ports.get(ch as usize) {
             return p.clone();
         }
     }
-    resolve_output(cfg, fake_audio)
+    resolve_output(cfg, state)
 }
 
 // ---------------------------------------------------------------------------

--- a/ac-rs/crates/ac-daemon/src/handlers/test_dut.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/test_dut.rs
@@ -28,13 +28,13 @@ pub fn test_dut(state: &ServerState, cmd: &Value) -> Value {
 
     let compare_mode = cmd.get("compare").and_then(Value::as_bool).unwrap_or(false);
     let level_dbfs   = cmd.get("level_dbfs").and_then(Value::as_f64).unwrap_or(-20.0);
-    let out_port     = resolve_output(&cfg, state.fake_audio);
-    let in_port      = resolve_input(&cfg, state.fake_audio);
-    let ref_port     = match resolve_ref_input(&cfg, state.fake_audio) {
+    let out_port     = resolve_output(&cfg, state);
+    let in_port      = resolve_input(&cfg, state);
+    let ref_port     = match resolve_ref_input(&cfg, state) {
         Some(p) => p,
         None    => in_port.clone(),
     };
-    let ref_out_port = resolve_ref_output(&cfg, state.fake_audio);
+    let ref_out_port = resolve_ref_output(&cfg, state);
     let out_ch       = cfg.output_channel;
     let in_ch        = cfg.input_channel;
 

--- a/ac-rs/crates/ac-daemon/src/handlers/test_hw.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/test_hw.rs
@@ -27,13 +27,13 @@ pub fn test_hardware(state: &ServerState, cmd: &Value) -> Value {
     }
 
     let dmm_mode     = cmd.get("dmm").and_then(Value::as_bool).unwrap_or(false);
-    let out_port     = resolve_output(&cfg, state.fake_audio);
-    let in_port      = resolve_input(&cfg, state.fake_audio);
-    let ref_port     = match resolve_ref_input(&cfg, state.fake_audio) {
+    let out_port     = resolve_output(&cfg, state);
+    let in_port      = resolve_input(&cfg, state);
+    let ref_port     = match resolve_ref_input(&cfg, state) {
         Some(p) => p,
         None    => in_port.clone(),
     };
-    let ref_out_port = resolve_ref_output(&cfg, state.fake_audio);
+    let ref_out_port = resolve_ref_output(&cfg, state);
 
     let pub_tx       = state.pub_tx.clone();
     let fake         = state.fake_audio;

--- a/ac-rs/crates/ac-daemon/src/handlers/transfer.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/transfer.rs
@@ -23,13 +23,13 @@ pub fn transfer(state: &ServerState, cmd: &Value) -> Value {
     }
 
     let level_dbfs   = cmd.get("level_dbfs").and_then(Value::as_f64).unwrap_or(-10.0);
-    let out_port     = resolve_output(&cfg, state.fake_audio);
-    let in_port      = resolve_input(&cfg, state.fake_audio);
-    let ref_port     = match resolve_ref_input(&cfg, state.fake_audio) {
+    let out_port     = resolve_output(&cfg, state);
+    let in_port      = resolve_input(&cfg, state);
+    let ref_port     = match resolve_ref_input(&cfg, state) {
         Some(p) => p,
         None    => in_port.clone(), // fallback: use same as input (loopback)
     };
-    let ref_out_port = resolve_ref_output(&cfg, state.fake_audio);
+    let ref_out_port = resolve_ref_output(&cfg, state);
 
     let pub_tx   = state.pub_tx.clone();
     let fake     = state.fake_audio;
@@ -135,7 +135,7 @@ pub fn transfer(state: &ServerState, cmd: &Value) -> Value {
         "out_port":    out_port_r,
         "in_port":     in_port_r,
         "ref_port":    ref_port_r,
-        "ref_out_port": resolve_ref_output(&state.cfg.lock().unwrap(), state.fake_audio),
+        "ref_out_port": resolve_ref_output(&state.cfg.lock().unwrap(), state),
     })
 }
 
@@ -147,10 +147,10 @@ pub fn probe(state: &ServerState, _cmd: &Value) -> Value {
     let cfg     = state.cfg.lock().unwrap().clone();
     let dmm_host = cfg.dmm_host.clone();
 
-    let (playback, capture) = {
-        let eng = make_engine(fake);
-        (eng.playback_ports(), eng.capture_ports())
-    };
+    let (playback, capture) = (
+        super::cached_playback_ports(state),
+        super::cached_capture_ports(state),
+    );
     let n_play = playback.len();
     let n_cap  = capture.len();
 

--- a/ac-rs/crates/ac-daemon/src/server.rs
+++ b/ac-rs/crates/ac-daemon/src/server.rs
@@ -45,6 +45,12 @@ pub struct ServerState {
     /// Optional channel to signal the running calibrate worker.
     /// Sends Option<f64>: Some(vrms) = user reading, None = skip.
     pub cal_reply_tx: Arc<Mutex<Option<Sender<Option<f64>>>>>,
+    /// Cached port lists. JACK port queries open a fresh probe client every
+    /// call, so before this cache `test_hardware` would build 4+ probe clients
+    /// per invocation just to resolve sticky port names. Populated lazily and
+    /// refreshed by the `devices` command.
+    pub playback_ports_cache: Arc<Mutex<Option<Vec<String>>>>,
+    pub capture_ports_cache:  Arc<Mutex<Option<Vec<String>>>>,
 }
 
 pub fn run(ctrl_port: u16, data_port: u16, local_only: bool, fake_audio: bool) -> Result<()> {
@@ -80,6 +86,8 @@ pub fn run(ctrl_port: u16, data_port: u16, local_only: bool, fake_audio: bool) -
         data_port,
         dut_reply_tx: Arc::new(Mutex::new(None)),
         cal_reply_tx: Arc::new(Mutex::new(None)),
+        playback_ports_cache: Arc::new(Mutex::new(None)),
+        capture_ports_cache:  Arc::new(Mutex::new(None)),
     };
 
     let mut items = [ctrl.as_poll_item(zmq::POLLIN)];


### PR DESCRIPTION
## Summary

PR #38 was merged into its stacked base branch (\`refactor/handlers-split-29\`)
rather than onto main, so commit \`1c61dfc\` — the port-cache performance fix
that closes #30 — never reached main. This PR lands that commit directly.

Same diff as #38, cherry-picked from the orphaned branch. Closes #30.

## Test plan

- [x] \`cargo build -p ac-daemon\` — clean, zero warnings
- [x] \`cargo test -p ac-daemon\` — 3 unit + 7 integration, all green
- [ ] Manual: \`test_hardware\` on real JACK, \`ac-daemon-probe\` client count stays at 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)