### PR TITLE
refactor!: drop legacy wire type names at v0.2.0 (#73)

### DIFF
--- a/ac-rs/Cargo.lock
+++ b/ac-rs/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "ac-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ac-core",
  "anyhow",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "ac-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "ac-daemon"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ac-core",
  "anyhow",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "ac-ui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ac-core",
  "anyhow",

--- a/ac-rs/ZMQ.md
+++ b/ac-rs/ZMQ.md
@@ -31,7 +31,7 @@ as an error after the per-command deadline.
 <topic> <json-object>\n
 ```
 
-e.g. `data {"type":"sweep_point", ...}` or `done {"cmd":"plot", ...}`.
+e.g. `data {"type":"measurement/frequency_response/point", ...}` or `done {"cmd":"plot", ...}`.
 
 Topics: `data`, `done`, `error`, `cal_prompt`, `cal_done`, `gpio`, `keepalive`.
 
@@ -65,32 +65,30 @@ stop consuming frames when it receives either of these:
 
 ---
 
-## Tiered frame types (transition)
+## Tiered frame types
 
-`ARCHITECTURE.md` introduces a two-tier model for the analysis stack:
+`ARCHITECTURE.md` defines a two-tier model for the analysis stack:
 
 - **Tier 1 — Reference measurement** (`measurement/…`): reproducible,
   archivable. Emitted by `plot` today; future `sweep`, `noise`, etc.
 - **Tier 2 — Live analysis** (`visualize/…`): responsive,
   display-first. Emitted by `monitor_spectrum`.
 
-During the transition window every live-analysis and per-point
-measurement frame is published **twice**: once with the legacy `"type"`
-value (e.g. `"sweep_point"`, `"spectrum"`), and once with the
-tier-prefixed equivalent. The payloads are byte-identical apart from
-the `"type"` field. Subscribers should prefer the tier-prefixed name
-and treat the legacy copy as redundant.
+Every frame carries a tier-prefixed `"type"`:
 
-| Tier  | Legacy `type`        | Tiered `type`                              |
-|-------|----------------------|--------------------------------------------|
-| 1     | `sweep_point`        | `measurement/frequency_response/point`     |
-| 1     | — (new)              | `measurement/frequency_response/complete`  |
-| 1     | — (new)              | `measurement/report`                       |
-| 2     | `spectrum`           | `visualize/spectrum`                       |
-| 2     | `cwt`                | `visualize/cwt`                            |
-| 2     | `fractional_octave`  | `visualize/fractional_octave`              |
+| Tier  | `type`                                      |
+|-------|---------------------------------------------|
+| 1     | `measurement/frequency_response/point`      |
+| 1     | `measurement/frequency_response/complete`   |
+| 1     | `measurement/report`                        |
+| 2     | `visualize/spectrum`                        |
+| 2     | `visualize/cwt`                             |
+| 2     | `visualize/fractional_octave`               |
+| 2     | `visualize/fractional_octave_leq`           |
 
-Legacy `type` names are scheduled for removal in `ac` v0.2.0.
+**v0.2.0 (breaking)** — legacy unprefixed `type` names
+(`sweep_point`, `spectrum`, `cwt`, `fractional_octave`) were removed.
+External SUB subscribers must switch to the tier-prefixed names.
 
 ### `measurement/report` frame
 
@@ -170,13 +168,13 @@ start_hz, stop_hz)`) and publishes the resulting per-band levels. A second
 
 ## Shared types
 
-### `sweep_point` frame
+### `measurement/frequency_response/point` frame
 
 Emitted by `plot` and `plot_level` for each measured frequency or level point.
 
 ```json
 {
-  "type":             "sweep_point",
+  "type":             "measurement/frequency_response/point",
   "cmd":              "plot" | "plot_level",
   "n":                <int>,          // 0-based sequence number
   "drive_db":         <float>,        // stimulus level in dBFS
@@ -835,7 +833,7 @@ engine path; real JACK / CPAL buffer-playback is a follow-up.
 ### `plot`
 
 Blocking point-by-point frequency sweep: plays a tone at each frequency and
-captures + analyses the loopback. Emits one `sweep_point` frame per frequency.
+captures + analyses the loopback. Emits one `measurement/frequency_response/point` frame per frequency.
 
 **Request**
 ```json
@@ -856,7 +854,7 @@ captures + analyses the loopback. Emits one `sweep_point` frame per frequency.
 
 **DATA** — one per frequency:
 ```json
-// topic: data  (sweep_point frame, see Shared types)
+// topic: data  (measurement/frequency_response/point frame, see Shared types)
 ```
 
 **DATA** — terminal:
@@ -870,7 +868,7 @@ captures + analyses the loopback. Emits one `sweep_point` frame per frequency.
 ### `plot_level`
 
 Blocking point-by-point level sweep at a fixed frequency. Plays and captures
-at each level step. Emits one `sweep_point` frame per level.
+at each level step. Emits one `measurement/frequency_response/point` frame per level.
 
 **Request**
 ```json
@@ -889,7 +887,7 @@ at each level step. Emits one `sweep_point` frame per level.
 { "ok": true, "out_port": "<port>", "in_port": "<port>" }
 ```
 
-**DATA** — one per level step (sweep_point frame, `"cmd": "plot_level"`,
+**DATA** — one per level step (measurement/frequency_response/point frame, `"cmd": "plot_level"`,
 includes `"freq_hz"` and `"drive_db"` fields).
 
 **DATA** — terminal:

--- a/ac-rs/crates/ac-cli/Cargo.toml
+++ b/ac-rs/crates/ac-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "ac-cli"
-version     = "0.1.0"
+version     = "0.2.0"
 edition     = "2021"
 description = "CLI for audio bench measurements — THD, sweeps, transfer functions, live spectrum"
 

--- a/ac-rs/crates/ac-cli/src/commands/plot.rs
+++ b/ac-rs/crates/ac-cli/src/commands/plot.rs
@@ -145,7 +145,7 @@ fn collect_sweep(client: &mut AcClient, cmd_name: &str) -> Vec<serde_json::Value
         let (topic, data) = frame;
 
         if topic == "data" {
-            if data.get("type").and_then(|v| v.as_str()) == Some("sweep_point") {
+            if data.get("type").and_then(|v| v.as_str()) == Some("measurement/frequency_response/point") {
                 io::print_freq_row(&data);
                 results.push(data);
             }

--- a/ac-rs/crates/ac-cli/src/commands/test.rs
+++ b/ac-rs/crates/ac-cli/src/commands/test.rs
@@ -50,7 +50,7 @@ pub fn run_hardware(cmd: &CommandKind, client: &mut AcClient) {
         let (topic, data) = frame;
 
         if topic == "data" {
-            if data.get("type").and_then(|v| v.as_str()) == Some("sweep_point") {
+            if data.get("type").and_then(|v| v.as_str()) == Some("measurement/frequency_response/point") {
                 io::print_freq_row(&data);
             }
         } else if topic == "done" {
@@ -108,7 +108,7 @@ pub fn run_dut(
         let (topic, data) = frame;
 
         if topic == "data" {
-            if data.get("type").and_then(|v| v.as_str()) == Some("sweep_point") {
+            if data.get("type").and_then(|v| v.as_str()) == Some("measurement/frequency_response/point") {
                 io::print_freq_row(&data);
                 results.push(data);
             }

--- a/ac-rs/crates/ac-core/Cargo.toml
+++ b/ac-rs/crates/ac-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ac-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Core audio measurement library — FFT, THD/THD+N, calibration, signal generation"
 

--- a/ac-rs/crates/ac-core/src/lib.rs
+++ b/ac-rs/crates/ac-core/src/lib.rs
@@ -3,39 +3,3 @@ pub mod measurement;
 pub mod visualize;
 
 pub mod config;
-
-// `transfer` is Tier 2 (live H1 estimator, display-first). A future
-// Tier 1 archival variant would build on top of this — see #70.
-#[deprecated(note = "use ac_core::visualize::transfer")]
-pub use visualize::transfer;
-
-// Legacy flat paths — emit deprecation warnings; slated for removal in
-// v0.2.0 (`ARCHITECTURE.md` transition window).
-#[deprecated(note = "use ac_core::shared::calibration")]
-pub use shared::calibration;
-#[deprecated(note = "use ac_core::shared::conversions")]
-pub use shared::conversions;
-#[deprecated(note = "use ac_core::shared::constants")]
-pub use shared::constants;
-#[deprecated(note = "use ac_core::shared::generator")]
-pub use shared::generator;
-#[deprecated(note = "use ac_core::shared::types")]
-pub use shared::types;
-
-#[deprecated(note = "use ac_core::visualize::cwt")]
-pub use visualize::cwt;
-#[deprecated(note = "use ac_core::visualize::aggregate")]
-pub use visualize::aggregate;
-#[deprecated(note = "use ac_core::visualize::fractional_octave")]
-pub use visualize::fractional_octave;
-
-// The old `analysis` module exposed both Tier 1 items (`analyze`,
-// `analyze_default`, `AnalysisResult`) and the Tier 2 `spectrum_only`.
-// A single `pub use` can't cover both destinations, so keep a thin
-// transitional module that re-exports from each tier.
-#[deprecated(note = "THD moved to ac_core::measurement::thd; spectrum_only moved to ac_core::visualize::spectrum")]
-pub mod analysis {
-    pub use crate::measurement::thd::{analyze, analyze_default, find_peak};
-    pub use crate::shared::types::AnalysisResult;
-    pub use crate::visualize::spectrum::spectrum_only;
-}

--- a/ac-rs/crates/ac-daemon/Cargo.toml
+++ b/ac-rs/crates/ac-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "ac-daemon"
-version     = "0.1.0"
+version     = "0.2.0"
 edition     = "2021"
 description = "ZMQ audio measurement server — JACK/CPAL audio I/O, FFT analysis, worker management"
 

--- a/ac-rs/crates/ac-daemon/src/handlers/audio/monitor.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/audio/monitor.rs
@@ -61,21 +61,6 @@ impl Integrator {
     }
 }
 
-/// Publish a live-analysis frame under both the legacy `type` value
-/// (e.g. `"spectrum"`) and the tiered equivalent (`"visualize/spectrum"`)
-/// during the transition window. Callers pass the already-built frame
-/// whose `type` is the legacy name; this helper forwards the legacy copy
-/// unchanged and sends a second copy with `type` rewritten to `tiered`.
-fn publish_visualize(
-    pub_tx: &crossbeam_channel::Sender<Vec<u8>>,
-    mut frame: Value,
-    tiered: &'static str,
-) {
-    send_pub(pub_tx, "data", &frame);
-    frame["type"] = json!(tiered);
-    send_pub(pub_tx, "data", &frame);
-}
-
 pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
     busy_guard!(state, "monitor_spectrum");
     let freq_hz = cmd.get("freq_hz").and_then(Value::as_f64).unwrap_or(1000.0);
@@ -284,7 +269,7 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                         .map(|d| d.as_nanos() as u64)
                         .unwrap_or(0);
                     let frame = json!({
-                        "type":        "cwt",
+                        "type":        "visualize/cwt",
                         "cmd":         "monitor_spectrum",
                         "channel":     channel,
                         "n_channels":  n_channels,
@@ -294,7 +279,7 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                         "timestamp":   ts_ns,
                         "xruns":       xruns_total,
                     });
-                    publish_visualize(&pub_tx, frame, "visualize/cwt");
+                    send_pub(&pub_tx, "data", &frame);
                     // Optional fractional-octave aggregation of the same
                     // CWT column: reuses `cwt_mags` / `cwt_freqs` — zero
                     // extra DSP cost when enabled.
@@ -322,7 +307,7 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                             }
                         }
                         let frac_frame = json!({
-                            "type":       "fractional_octave",
+                            "type":       "visualize/fractional_octave",
                             "cmd":        "monitor_spectrum",
                             "channel":    channel,
                             "n_channels": n_channels,
@@ -334,7 +319,7 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                             "timestamp":  ts_ns,
                             "xruns":      xruns_total,
                         });
-                        publish_visualize(&pub_tx, frac_frame, "visualize/fractional_octave");
+                        send_pub(&pub_tx, "data", &frac_frame);
 
                         if cur_ti_mode != "off" {
                             let n_bands = band_levels.len();
@@ -362,7 +347,7 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                                 };
                                 let dur_s = integ.duration_s();
                                 let leq_frame = json!({
-                                    "type":       "fractional_octave_leq",
+                                    "type":       "visualize/fractional_octave_leq",
                                     "cmd":        "monitor_spectrum",
                                     "channel":    channel,
                                     "n_channels": n_channels,
@@ -377,11 +362,7 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                                     "timestamp":  ts_ns,
                                     "xruns":      xruns_total,
                                 });
-                                publish_visualize(
-                                    &pub_tx,
-                                    leq_frame,
-                                    "visualize/fractional_octave_leq",
-                                );
+                                send_pub(&pub_tx, "data", &leq_frame);
                             }
                         }
                     }
@@ -452,7 +433,7 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                                 ac_core::visualize::aggregate::DEFAULT_WIRE_COLUMNS,
                             );
                             json!({
-                                "type":             "spectrum",
+                                "type":             "visualize/spectrum",
                                 "cmd":              "monitor_spectrum",
                                 "channel":          channel,
                                 "n_channels":       n_channels,
@@ -479,7 +460,7 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                                 ac_core::visualize::aggregate::DEFAULT_WIRE_COLUMNS,
                             );
                             json!({
-                                "type":             "spectrum",
+                                "type":             "visualize/spectrum",
                                 "cmd":              "monitor_spectrum",
                                 "channel":          channel,
                                 "n_channels":       n_channels,
@@ -490,7 +471,7 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                             })
                         }
                     };
-                    publish_visualize(&pub_tx, frame, "visualize/spectrum");
+                    send_pub(&pub_tx, "data", &frame);
                 }
             }
             // Pace FFT mode to requested interval. CWT has its own cadence

--- a/ac-rs/crates/ac-daemon/src/handlers/audio/plot.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/audio/plot.rs
@@ -20,19 +20,6 @@ use super::super::{
     busy_guard, resolve_input, resolve_output, send_pub, spawn_worker, sweep_point_frame,
 };
 
-/// Publish a per-point frame under both the legacy `sweep_point` name
-/// and its tiered equivalent. Callers pass the already-built frame
-/// (whose `type` field is `sweep_point`); this helper forwards the
-/// legacy copy unchanged and sends a second copy with `type` replaced.
-fn publish_sweep_point(
-    pub_tx: &crossbeam_channel::Sender<Vec<u8>>,
-    mut frame: Value,
-) {
-    send_pub(pub_tx, "data", &frame);
-    frame["type"] = json!("measurement/frequency_response/point");
-    send_pub(pub_tx, "data", &frame);
-}
-
 fn now_iso8601_utc() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
@@ -102,7 +89,7 @@ pub fn plot(state: &ServerState, cmd: &Value) -> Value {
                         ac_coupled:       r.ac_coupled,
                     });
                     let frame = sweep_point_frame(&r, cal.as_ref(), n, "plot", level_dbfs, Some(*freq));
-                    publish_sweep_point(&pub_tx, frame);
+                    send_pub(&pub_tx, "data", &frame);
                     n += 1;
                 }
                 Err(e) => eprintln!("plot: analyze error at {freq}Hz: {e}"),

--- a/ac-rs/crates/ac-daemon/src/handlers/mod.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/mod.rs
@@ -260,7 +260,7 @@ pub(super) fn sweep_point_frame(
         .collect();
 
     let mut frame = json!({
-        "type":              "sweep_point",
+        "type":              "measurement/frequency_response/point",
         "cmd":               cmd_name,
         "n":                 n,
         "drive_db":          level_dbfs,

--- a/ac-rs/crates/ac-ui/Cargo.toml
+++ b/ac-rs/crates/ac-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "ac-ui"
-version     = "0.1.0"
+version     = "0.2.0"
 edition     = "2021"
 build       = "build.rs"
 description = "GPU audio measurement UI — wgpu spectrum/waterfall/CWT, egui transfer/sweep views"

--- a/ac-rs/crates/ac-ui/src/data/receiver.rs
+++ b/ac-rs/crates/ac-ui/src/data/receiver.rs
@@ -160,7 +160,7 @@ pub fn spawn(
                         .and_then(|v| v.get("type"))
                         .and_then(|t| t.as_str())
                         .map(|s| s.to_string());
-                    if type_tag.as_deref() == Some("cwt") {
+                    if type_tag.as_deref() == Some("visualize/cwt") {
                         // Morlet CWT column: magnitudes are already dBFS and
                         // frequencies are log-spaced. Repackage as a
                         // SpectrumFrame so the existing display pipeline
@@ -206,7 +206,7 @@ pub fn spawn(
                         inputs[slot].write(frame);
                         continue;
                     }
-                    if type_tag.as_deref() == Some("fractional_octave") {
+                    if type_tag.as_deref() == Some("visualize/fractional_octave") {
                         // 1/N-octave aggregation of the CWT column. Daemon
                         // emits this in addition to the `cwt` frame each
                         // tick when `set_ioct_bpo` has enabled it. Schema
@@ -248,7 +248,7 @@ pub fn spawn(
                         inputs[slot].write(sf);
                         continue;
                     }
-                    if type_tag.as_deref() == Some("fractional_octave_leq") {
+                    if type_tag.as_deref() == Some("visualize/fractional_octave_leq") {
                         // Time-integrated sidecar to `fractional_octave` (see
                         // ZMQ.md § time-integration). Publishers emit this
                         // immediately after the corresponding `fractional_octave`
@@ -350,7 +350,7 @@ pub fn spawn(
                         }
                         continue;
                     }
-                    if type_tag.as_deref() == Some("sweep_point") {
+                    if type_tag.as_deref() == Some("measurement/frequency_response/point") {
                         match serde_json::from_str::<SweepPoint>(body) {
                             Ok(pt) => {
                                 log::debug!(

--- a/tests/test_server_client.py
+++ b/tests/test_server_client.py
@@ -27,12 +27,8 @@ def recv_until(client, done_topics=("done", "error"), max_frames=200, timeout_ms
     return frames
 
 
-# Frame `type` values emitted by plot/plot_level per frequency point.
-# Transition-era: daemon emits both the legacy `sweep_point` and the
-# tier-prefixed `measurement/frequency_response/point` for the same
-# payload. Tests assert membership in this set.
-SWEEP_POINT_TYPES = ("sweep_point", "measurement/frequency_response/point")
-SPECTRUM_TYPES    = ("spectrum",    "visualize/spectrum")
+SWEEP_POINT_TYPE = "measurement/frequency_response/point"
+SPECTRUM_TYPE    = "visualize/spectrum"
 
 
 def _drain(client, max_frames=200, timeout_ms=1000):
@@ -155,7 +151,7 @@ def test_plot_fields(server_client):
     data_frames = [f for t, f in frames if t == "data"]
     assert data_frames, "expected at least one sweep_point from plot"
 
-    sp_frames = [f for f in data_frames if f.get("type") in SWEEP_POINT_TYPES]
+    sp_frames = [f for f in data_frames if f.get("type") == SWEEP_POINT_TYPE]
     assert sp_frames, "expected at least one sweep_point frame from plot"
     for f in sp_frames:
         assert "thd_pct"    in f
@@ -347,7 +343,7 @@ def test_plot_level_fields(server_client):
     data_frames = [f for t, f in frames if t == "data"]
     assert data_frames, "expected at least one sweep_point from plot_level"
 
-    sp_frames = [f for f in data_frames if f.get("type") in SWEEP_POINT_TYPES]
+    sp_frames = [f for f in data_frames if f.get("type") == SWEEP_POINT_TYPE]
     assert sp_frames, "expected at least one sweep_point frame from plot_level"
     for f in sp_frames:
         assert f.get("cmd")  == "plot_level"
@@ -404,7 +400,7 @@ def test_sweep_point_none_fields_are_numeric_safe(server_client):
 
     frames = recv_until(client, done_topics=("done", "error"), timeout_ms=30000)
     data_frames = [f for t, f in frames
-                   if t == "data" and f.get("type") in SWEEP_POINT_TYPES]
+                   if t == "data" and f.get("type") == SWEEP_POINT_TYPE]
     assert data_frames
 
     # The test server has no calibration, so these fields should be None
@@ -441,7 +437,7 @@ def test_plot_thd_numerical_accuracy(server_client):
 
     frames = recv_until(client, done_topics=("done", "error"), timeout_ms=30000)
     data_frames = [f for t, f in frames
-                   if t == "data" and f.get("type") in SWEEP_POINT_TYPES]
+                   if t == "data" and f.get("type") == SWEEP_POINT_TYPE]
     assert data_frames, "expected at least one sweep_point"
 
     f = data_frames[0]
@@ -497,7 +493,7 @@ def test_monitor_spectrum_frames(server_client):
             topic, frame = client.recv_data(timeout_ms=3000)
         except TimeoutError:
             break
-        if topic == "data" and frame.get("type") in SPECTRUM_TYPES:
+        if topic == "data" and frame.get("type") == SPECTRUM_TYPE:
             spec_frames.append(frame)
             if len(spec_frames) >= 2:
                 break


### PR DESCRIPTION
## Summary
- Daemon emits only the tier-prefixed `type` strings (`measurement/frequency_response/point`, `visualize/spectrum`, `visualize/cwt`, `visualize/fractional_octave`, `visualize/fractional_octave_leq`); legacy unprefixed names are gone.
- Remove the `#[deprecated]` flat re-exports in `ac_core::lib` (`ac_core::analysis`, `::calibration`, `::conversions`, `::constants`, `::generator`, `::types`, `::cwt`, `::aggregate`, `::fractional_octave`).
- Update CLI + UI subscribers (plot.rs, test.rs, receiver.rs) to match, and the pytest harness to assert a single tiered name.
- Bump all four crates to 0.2.0; refresh `ZMQ.md` (drop transition table, call out removal).

Breaking change for external SUB subscribers — covered by the v0.2.0 bump.

Closes #73.

## Test plan
- [x] `cargo test` — 402 tests green
- [x] `pytest tests/ -q` — 23 passed against the rebuilt daemon (no legacy frames observed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)