### PR TITLE
feat(ac-core): MeasurementMethod::SweptSine for Farina log-sweep (#82)

### DIFF
--- a/ac-rs/ZMQ.md
+++ b/ac-rs/ZMQ.md
@@ -125,6 +125,13 @@ see an unknown version must refuse to decode. Example payload:
 }
 ```
 
+`method.kind` values currently defined:
+
+| `kind`          | Producer      | Extra fields                                                                                  |
+|-----------------|---------------|-----------------------------------------------------------------------------------------------|
+| `stepped_sine`  | `plot`        | `{ "n_points": <int>, "standard": <StandardsCitation?> }`                                     |
+| `swept_sine`    | `sweep_ir`    | `{ "f1_hz": <f>, "f2_hz": <f>, "duration_s": <f>, "standard": <StandardsCitation?> }`         |
+
 `data.kind` values currently defined:
 
 | `kind`                 | Producer                                           | Payload shape                                                                     |

--- a/ac-rs/crates/ac-core/src/measurement/report.rs
+++ b/ac-rs/crates/ac-core/src/measurement/report.rs
@@ -38,8 +38,21 @@ pub struct MeasurementReport {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MeasurementMethod {
+    /// Discrete-frequency stepped-sine sweep — one tone per bin, fundamental
+    /// analyzed in isolation (`measurement::thd::analyze`). Used by `plot`.
     SteppedSine {
         n_points: usize,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        standard: Option<StandardsCitation>,
+    },
+    /// Continuous log-swept sine (Farina ESS) — stimulus is a single
+    /// exponential sweep from `f1_hz` to `f2_hz` over `duration_s`; the
+    /// captured response is processed by deconvolution or a fractional-
+    /// octave filterbank. Used by `sweep_ir`.
+    SweptSine {
+        f1_hz: f64,
+        f2_hz: f64,
+        duration_s: f64,
         #[serde(skip_serializing_if = "Option::is_none")]
         standard: Option<StandardsCitation>,
     },
@@ -328,6 +341,28 @@ mod tests {
     }
 
     #[test]
+    fn swept_sine_method_round_trip() {
+        let mut r = sample_report();
+        r.method = MeasurementMethod::SweptSine {
+            f1_hz: 20.0,
+            f2_hz: 20_000.0,
+            duration_s: 3.0,
+            standard: Some(StandardsCitation {
+                standard: "Farina 2000 (AES 108)".into(),
+                clause: "Swept-sine technique for IR and distortion".into(),
+                verified: false,
+            }),
+        };
+        let json = r.to_json().unwrap();
+        assert!(json.contains("\"kind\": \"swept_sine\""));
+        assert!(json.contains("\"f1_hz\": 20.0"));
+        assert!(json.contains("\"f2_hz\": 20000.0"));
+        assert!(json.contains("\"duration_s\": 3.0"));
+        let r2: MeasurementReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(r, r2);
+    }
+
+    #[test]
     fn schema_version_present() {
         let r = sample_report();
         let json = r.to_json().unwrap();
@@ -407,8 +442,10 @@ mod tests {
             schema_version: SCHEMA_VERSION,
             ac_version: "0.1.0".into(),
             timestamp_utc: "2026-04-22T12:00:00Z".into(),
-            method: MeasurementMethod::SteppedSine {
-                n_points: 0,
+            method: MeasurementMethod::SweptSine {
+                f1_hz: 20.0,
+                f2_hz: 20_000.0,
+                duration_s: 1.0,
                 standard: Some(StandardsCitation {
                     standard: "Farina 2000 (AES 108)".into(),
                     clause: "Swept-sine technique for IR and distortion".into(),

--- a/ac-rs/crates/ac-core/src/measurement/report_html.rs
+++ b/ac-rs/crates/ac-core/src/measurement/report_html.rs
@@ -101,6 +101,22 @@ fn write_method(out: &mut String, r: &MeasurementReport) {
                 );
             }
         }
+        MeasurementMethod::SweptSine { f1_hz, f2_hz, duration_s, standard } => {
+            let _ = writeln!(
+                out,
+                "<dt>kind</dt><dd>swept_sine ({:.1} Hz → {:.1} Hz, {:.3} s)</dd>",
+                f1_hz, f2_hz, duration_s
+            );
+            if let Some(s) = standard {
+                let _ = writeln!(
+                    out,
+                    "<dt>standard</dt><dd>{} — {}{}</dd>",
+                    html_escape(&s.standard),
+                    html_escape(&s.clause),
+                    if s.verified { " ✓ verified" } else { "" }
+                );
+            }
+        }
     }
     let _ = writeln!(
         out,

--- a/ac-rs/crates/ac-daemon/src/handlers/audio/sweep.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/audio/sweep.rs
@@ -205,8 +205,10 @@ pub fn sweep_ir(state: &ServerState, cmd: &Value) -> Value {
             schema_version: SCHEMA_VERSION,
             ac_version: env!("CARGO_PKG_VERSION").to_string(),
             timestamp_utc: chrono::Utc::now().to_rfc3339(),
-            method: MeasurementMethod::SteppedSine {
-                n_points: 0,
+            method: MeasurementMethod::SweptSine {
+                f1_hz,
+                f2_hz,
+                duration_s: duration,
                 standard: Some(sweep_citation()),
             },
             stimulus: StimulusParams {


### PR DESCRIPTION
## Summary
- Add `MeasurementMethod::SweptSine { f1_hz, f2_hz, duration_s, standard }` to `ac-core::measurement::report` and serialize as `\"kind\": \"swept_sine\"`.
- Switch the daemon's `sweep_ir` handler to tag its `MeasurementReport` with `SweptSine` (was `SteppedSine { n_points: 0 }` which was misleading).
- Extend the HTML renderer to format the new variant; round-trip test added.
- Document the `method.kind` table in `ZMQ.md`.
- `plot` (discrete stepped-sine) keeps `SteppedSine` — no change.

Closes #82.

## Test plan
- [x] `cargo test -p ac-core` — 160 passed (new `swept_sine_method_round_trip`)
- [x] `cargo test` — full workspace green

🤖 Generated with [Claude Code](https://claude.com/claude-code)