### PR TITLE
test: mark test_hardware / test_dut as slow (skipped by default)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,13 @@ Sets Mic-AN1/AN2 gain to 0, Line-IN3/4 sensitivity to +4 dBu, Line-IN3/4 gain to
 Run all tests before committing:
 ```bash
 cd ac-rs && cargo test
-pytest tests/ -q                # black-box ZMQ protocol tests (spawns Rust daemon)
+pytest tests/ -q                # black-box ZMQ protocol tests — default ~20 s
+pytest tests/ --runslow -q      # + extended (`test_hardware`, `test_dut`) ~3 min
 ```
+
+Two long pytest scenarios (`test_test_hardware_frames`, `test_test_dut_frames`)
+are marked `slow` and skipped by default. Pass `--runslow` to include them, or
+`pytest -m slow --runslow` to run *only* the extended suite.
 
 ## ds — diagnostics session manager
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,37 @@ import zmq
 
 
 # ---------------------------------------------------------------------------
+# Marker: slow tests (`test_hardware`, `test_dut` drive the full battery
+# against the fake engine and dominate wall-clock — ~2 min each). Skipped
+# by default; opt in with `pytest --runslow` or `pytest -m slow`.
+# ---------------------------------------------------------------------------
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False,
+        help="run tests marked `slow` (extended suite: multi-minute)",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "slow: long-running test; skipped unless --runslow or -m slow"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    # If the user explicitly selected slow tests via `-m`, respect that.
+    if "slow" in (config.getoption("-m") or ""):
+        return
+    skip_slow = pytest.mark.skip(reason="slow (pass --runslow to include)")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server_client.py
+++ b/tests/test_server_client.py
@@ -560,6 +560,7 @@ def _ensure_reference_channel(client, channel=1):
 # test_hardware
 # ---------------------------------------------------------------------------
 
+@pytest.mark.slow
 def test_test_hardware_frames(server_client):
     """test_hardware emits test_result frames with required fields then done."""
     client = server_client
@@ -597,6 +598,7 @@ def test_test_hardware_frames(server_client):
 # test_dut
 # ---------------------------------------------------------------------------
 
+@pytest.mark.slow
 def test_test_dut_frames(server_client):
     """test_dut emits test_result frames with required fields then done."""
     client = server_client


### PR DESCRIPTION
## Summary
- `test_test_hardware_frames` (~141 s) and `test_test_dut_frames` (~60 s) together account for ~200 s of a ~220 s pytest run. Mark both `@pytest.mark.slow`.
- `conftest.py`: add `--runslow` option and a `pytest_collection_modifyitems` hook that skips the marker unless `--runslow` is given (or `-m slow` explicitly selects it).
- Default `pytest tests/ -q` now runs in ~19 s.
- Document the opt-in in `CLAUDE.md`.

## Opt-ins
```
pytest tests/ --runslow            # full suite (~3 min)
pytest tests/ -m slow --runslow    # only the two slow scenarios
```

## Test plan
- [x] Default run: 21 passed, 2 skipped in 18.47 s
- [x] `--runslow -m slow`: 2 passed in 201 s (pair still green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)