### PR TITLE
feat: unify daemon timestamps + filenames on UTC ISO-8601

### DIFF
--- a/ac-rs/crates/ac-cli/src/io.rs
+++ b/ac-rs/crates/ac-cli/src/io.rs
@@ -157,7 +157,7 @@ pub fn output_dir(cfg: &ac_core::config::Config) -> std::path::PathBuf {
 }
 
 pub fn timestamp() -> String {
-    chrono::Local::now().format("%Y%m%d_%H%M%S").to_string()
+    ac_core::shared::time::now_utc_filename_stamp()
 }
 
 pub fn print_freq_header(have_cal: bool) {

--- a/ac-rs/crates/ac-core/src/shared/calibration.rs
+++ b/ac-rs/crates/ac-core/src/shared/calibration.rs
@@ -162,7 +162,7 @@ pub fn parse_mic_curve(text: &str, source_path: Option<String>) -> Result<MicRes
         freqs_hz:    freqs,
         gain_db:     gains,
         source_path,
-        imported_at: chrono::Utc::now().to_rfc3339(),
+        imported_at: crate::shared::time::now_utc_iso8601(),
     })
 }
 

--- a/ac-rs/crates/ac-core/src/shared/mod.rs
+++ b/ac-rs/crates/ac-core/src/shared/mod.rs
@@ -8,4 +8,5 @@ pub(crate) mod fft_cache;
 pub mod generator;
 pub mod mic_curve_filter;
 pub mod reference_levels;
+pub mod time;
 pub mod types;

--- a/ac-rs/crates/ac-core/src/shared/time.rs
+++ b/ac-rs/crates/ac-core/src/shared/time.rs
@@ -1,0 +1,62 @@
+//! Tier 0 — canonical timestamp formatting.
+//!
+//! All daemon-emitted timestamps and on-disk artefacts use UTC ISO-8601 so
+//! every surface agrees on a single, unambiguous representation:
+//!
+//! - [`now_utc_iso8601`] — human/report/frame timestamps, `2026-05-27T14:22:08Z`.
+//! - [`now_utc_filename_stamp`] — the same instant compacted for filenames,
+//!   `20260527T142208Z` (no separators, filesystem-safe, still sorts).
+
+/// Format string for display/report/frame timestamps (`%Y-%m-%dT%H:%M:%SZ`).
+const ISO8601_UTC: &str = "%Y-%m-%dT%H:%M:%SZ";
+
+/// Format string for filename stamps (`%Y%m%dT%H%M%SZ`).
+const ISO8601_UTC_COMPACT: &str = "%Y%m%dT%H%M%SZ";
+
+/// Current UTC time as `2026-05-27T14:22:08Z`.
+///
+/// The canonical timestamp for `MeasurementReport`, daemon frames, calibration
+/// `imported_at`, and CSV export headers.
+pub fn now_utc_iso8601() -> String {
+    chrono::Utc::now().format(ISO8601_UTC).to_string()
+}
+
+/// Current UTC time as `20260527T142208Z`, for embedding in filenames.
+pub fn now_utc_filename_stamp() -> String {
+    chrono::Utc::now().format(ISO8601_UTC_COMPACT).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iso8601_has_expected_shape() {
+        let s = now_utc_iso8601();
+        // `YYYY-MM-DDTHH:MM:SSZ` — 20 chars, trailing Z, T separator.
+        assert_eq!(s.len(), 20, "got {s:?}");
+        assert!(s.ends_with('Z'), "got {s:?}");
+        assert_eq!(s.as_bytes()[10], b'T', "got {s:?}");
+        assert_eq!(s.as_bytes()[4], b'-', "got {s:?}");
+        assert_eq!(s.as_bytes()[13], b':', "got {s:?}");
+        // Round-trips through chrono's RFC3339 parser.
+        assert!(chrono::DateTime::parse_from_rfc3339(&s).is_ok(), "got {s:?}");
+    }
+
+    #[test]
+    fn filename_stamp_has_expected_shape() {
+        let s = now_utc_filename_stamp();
+        // `YYYYMMDDTHHMMSSZ` — 16 chars, trailing Z, no separators except T.
+        assert_eq!(s.len(), 16, "got {s:?}");
+        assert!(s.ends_with('Z'), "got {s:?}");
+        assert_eq!(s.as_bytes()[8], b'T', "got {s:?}");
+        assert!(
+            s[..8].bytes().all(|b| b.is_ascii_digit()),
+            "date part not all digits: {s:?}"
+        );
+        assert!(
+            s[9..15].bytes().all(|b| b.is_ascii_digit()),
+            "time part not all digits: {s:?}"
+        );
+    }
+}

--- a/ac-rs/crates/ac-daemon/src/handlers/audio/plot.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/audio/plot.rs
@@ -22,10 +22,6 @@ use super::super::{
 };
 use crate::handlers::mic;
 
-fn now_iso8601_utc() -> String {
-    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
-}
-
 pub fn plot(state: &ServerState, cmd: &Value) -> Value {
     busy_guard!(state, "plot");
     let start_hz   = cmd.get("start_hz")  .and_then(Value::as_f64).unwrap_or(20.0);
@@ -132,7 +128,7 @@ pub fn plot(state: &ServerState, cmd: &Value) -> Value {
         eng.set_silence();
         eng.stop();
 
-        let timestamp = now_iso8601_utc();
+        let timestamp = ac_core::shared::time::now_utc_iso8601();
         // Snapshot the processing-chain state at report-build time so a
         // re-loaded report tells the reader what was active during this
         // capture (#105). `mic_correction_applied` reads true exactly

--- a/ac-rs/crates/ac-daemon/src/handlers/audio/sweep.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/audio/sweep.rs
@@ -213,7 +213,7 @@ pub fn sweep_ir(state: &ServerState, cmd: &Value) -> Value {
         let report = MeasurementReport {
             schema_version: SCHEMA_VERSION,
             ac_version: env!("CARGO_PKG_VERSION").to_string(),
-            timestamp_utc: chrono::Utc::now().to_rfc3339(),
+            timestamp_utc: ac_core::shared::time::now_utc_iso8601(),
             method: MeasurementMethod::SweptSine {
                 f1_hz,
                 f2_hz,

--- a/ac-rs/crates/ac-daemon/src/handlers/calibrate.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/calibrate.rs
@@ -236,7 +236,7 @@ pub fn calibrate_mic_curve(state: &ServerState, cmd: &Value) -> Value {
                 freqs_hz,
                 gain_db,
                 source_path,
-                imported_at: chrono::Utc::now().to_rfc3339(),
+                imported_at: ac_core::shared::time::now_utc_iso8601(),
             });
         }
         other => {

--- a/ac-rs/crates/ac-ui/src/ui/export.rs
+++ b/ac-rs/crates/ac-ui/src/ui/export.rs
@@ -24,7 +24,7 @@ pub fn spawn_save(req: ScreenshotRequest) {
 
 fn save(req: ScreenshotRequest) -> anyhow::Result<()> {
     std::fs::create_dir_all(&req.output_dir)?;
-    let stamp = chrono::Local::now().format("%Y%m%d_%H%M%S").to_string();
+    let stamp = ac_core::shared::time::now_utc_filename_stamp();
     let prefix = if req.transfer.is_some() { "transfer" } else { "spectrum" };
     let png_path = req.output_dir.join(format!("{prefix}_{stamp}.png"));
     let csv_path = req.output_dir.join(format!("{prefix}_{stamp}.csv"));
@@ -84,7 +84,7 @@ fn write_csv(path: &std::path::Path, frames: &[Option<DisplayFrame>]) -> anyhow:
     // numpy.loadtxt with default settings). Records the cal layers and
     // processing-context that were active at capture time so a re-load
     // years later can interpret the dB values correctly. See #100.
-    let stamp = chrono::Utc::now().to_rfc3339();
+    let stamp = ac_core::shared::time::now_utc_iso8601();
     writeln!(f, "# ac monitor export — {stamp}")?;
     if let Some(first) = active.first() {
         writeln!(f, "# sample_rate_hz: {}", first.meta.sr)?;


### PR DESCRIPTION
closes #120

### what changed
Collapsed three coexisting string timestamp formats (RFC3339 with subsecond+offset, `%Y-%m-%dT%H:%M:%SZ`, and local `%Y%m%d_%H%M%S` filename stamps) onto a single canonical pair, sourced from one new `ac-core::shared::time` module: `now_utc_iso8601()` for report/frame/`imported_at` strings and `now_utc_filename_stamp()` for filenames. Now that `ds` is gone (#119), the filename cutover is safe — no consumer depends on the old local-time `_`-separated stems.

### files touched
- `ac-rs/crates/ac-core/src/shared/time.rs` — **new.** `now_utc_iso8601()` → `2026-05-27T14:22:08Z`; `now_utc_filename_stamp()` → `20260527T142208Z`. Single source of truth + 2 unit tests asserting shape and RFC3339 round-trip.
- `ac-rs/crates/ac-core/src/shared/mod.rs` — register `time` module.
- `ac-rs/crates/ac-core/src/shared/calibration.rs` — `MicResponse.imported_at` now `now_utc_iso8601()` (was `to_rfc3339()`).
- `ac-rs/crates/ac-daemon/src/handlers/audio/sweep.rs` — `MeasurementReport.timestamp_utc` unified (was `to_rfc3339()`).
- `ac-rs/crates/ac-daemon/src/handlers/audio/plot.rs` — use shared helper; removed redundant local `now_iso8601_utc()`.
- `ac-rs/crates/ac-daemon/src/handlers/calibrate.rs` — `imported_at` unified (was `to_rfc3339()`).
- `ac-rs/crates/ac-cli/src/io.rs` — `timestamp()` (used by plot/test CSV export filenames) now compact UTC (was local `%Y%m%d_%H%M%S`).
- `ac-rs/crates/ac-ui/src/ui/export.rs` — screenshot/CSV filename stamp → compact UTC; CSV header timestamp → `now_utc_iso8601()`.

### test output
```
ac-core   267 passed; 0 failed   (+2 new: shared::time::tests)
ac-cli     80 +  47 passed; 0 failed
ac-daemon  63 passed; 0 failed  + 1 ignored (JACK runbook)
ac-ui     221 passed; 0 failed  + 2 ignored (wgpu runbook)
integ       4 passed; 0 failed
total     682 passed; 0 failed; 3 ignored
```
`cargo fmt --check` clean (0 diffs). `cargo clippy -- -D warnings`: zero new lints vs `main` (pre-existing workspace lints from rust-1.95.0 toolchain drift, untouched — same as #123).

### ZMQ schema changed
no — field *values* change format (string stays string); no field added/removed/renamed. `MeasurementReport.timestamp_utc` and `MicResponse.imported_at` are serialized as-is. There is **no timestamp parsing layer** anywhere (renderers/UI display the string verbatim), so no consumer breaks.

### new dependencies
none — `chrono` (with `clock`) already a dep of all three crates.

### related
none

### open questions for reviewer
- **Scope of "frames":** numeric epoch-nanosecond timestamps (`ts_ns`) in monitor/spectrum live frames were left unchanged — they're a data time base for plotting, not a human-readable timestamp format, and ISO-stringifying them would break the UI time axis. Flagging in case you read AC #1 ("daemon-emitted timestamps in frames") more broadly.
- **Precision drop:** moving off `to_rfc3339()` drops sub-second precision and the explicit `+00:00` offset (now `Z`) on `timestamp_utc` / `imported_at`. Intended per the spec's `%Y-%m-%dT%H:%M:%SZ` target; calling it out since it's a visible change to archived report/cal files.
- **Filename cutover:** existing on-disk files keep their old `spectrum_20260527_142208.png` names; only newly written files use `spectrum_20260527T142208Z.png`. No migration of old artefacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)