### PR TITLE
test: remove false coverage signal in measurement tests

### DIFF
--- a/ac-rs/crates/ac-core/src/measurement/filterbank.rs
+++ b/ac-rs/crates/ac-core/src/measurement/filterbank.rs
@@ -335,11 +335,18 @@ mod tests {
             .collect()
     }
 
-    /// Class 1 tolerance lower bound on attenuation at the ±1-band
-    /// neighbour (dB). Derived from IEC 61260-1:2014 Table 2: the relative
-    /// frequency for the ±1-band neighbour falls in the high-stopband
-    /// region with minimum attenuation ≥ 17.5 dB regardless of bpo.
-    fn class1_neighbour_min_atten_db(_bpo: usize) -> f64 {
+    /// Conservative lower bound (dB) on the attenuation the filterbank must
+    /// reach at the ±1-band neighbour. Used as a regression floor.
+    ///
+    /// IEC 61260-1:2014 §5.10 specifies the relative-attenuation acceptance
+    /// limits as a function of f/fm (Table 1 for octave bands, Annex F
+    /// Table F.1 for one-third-octave bands). Those limits permit *less*
+    /// rejection at the immediate neighbour as the bands narrow, and the
+    /// standard tabulates only the 1/1- and 1/3-octave cases. Rather than
+    /// extrapolate a per-bpo limit, this is a single fixed floor that the
+    /// implementation clears for every supported bpo — a deliberately
+    /// bpo-independent regression bound, not the full per-band IEC mask.
+    fn class1_neighbour_min_atten_db() -> f64 {
         17.5
     }
 
@@ -454,7 +461,7 @@ mod tests {
             let duration_s = duration_for_bpo(bpo);
             let n = (duration_s * SR as f64) as usize;
             let amp = 1.0; // 0 dBFS (peak = full scale)
-            let min_atten = class1_neighbour_min_atten_db(bpo);
+            let min_atten = class1_neighbour_min_atten_db();
 
             // Pick an interior band.
             let interior = centres.len() / 2;
@@ -566,8 +573,8 @@ mod tests {
 
     #[test]
     fn class1_mask_at_1khz() {
-        // IEC 61260-1:2014 §5.4 Table 2: the 1/3-octave Class 1 band
-        // response must lie within a symmetric tolerance window. At the
+        // IEC 61260-1:2014 §5.10 (Annex F Table F.1): the 1/3-octave Class 1
+        // band response must lie within a symmetric tolerance window. At the
         // ±(1/(8·bpo))-octave offsets near the passband we allow
         // ±0.3 dB / −∞ dB (the lower bound is generous); we assert the
         // upper bound − that the filter is not unexpectedly hot − which

--- a/ac-rs/crates/ac-core/src/measurement/thd.rs
+++ b/ac-rs/crates/ac-core/src/measurement/thd.rs
@@ -306,9 +306,19 @@ mod tests {
 
     #[test]
     fn wrong_fundamental_returns_error_or_high_thd() {
+        // Signal is a pure 1 kHz tone, but we tell `analyze` the fundamental
+        // is 2 kHz. The 2 kHz bin holds no real tone, so either the
+        // fundamental-energy guard trips (Err) or the THD ratio blows up.
         let samples = pure_sine(1_000.0, 0.5, SR, SR as usize);
-        let result = analyze(&samples, SR, 2_000.0, 10);
-        let _ = result;
+        // An `Err` (fundamental-energy guard tripped) is an acceptable
+        // outcome; if it does return Ok, the THD ratio must be blown out.
+        if let Ok(r) = analyze(&samples, SR, 2_000.0, 10) {
+            assert!(
+                r.thd_pct > 10.0,
+                "wrong fundamental should yield high THD, got {:.4}%",
+                r.thd_pct
+            );
+        }
     }
 
     #[test]

--- a/ac-rs/crates/ac-core/src/measurement/weighting.rs
+++ b/ac-rs/crates/ac-core/src/measurement/weighting.rs
@@ -314,7 +314,7 @@ mod tests {
         // 8 kHz → ±(2.1, 3.1) dB (use the tighter 2.1 for pass), 16 kHz →
         // +3.5/-17 dB (skip — tolerance unbounded below).
         let f = WeightingFilter::new(Weighting::A, FS).unwrap();
-        for &(fr, tol) in &[(31.0_f64, 1.5), (1000.0, 0.7), (4000.0, 1.6), (8000.0, 2.1)] {
+        for &(fr, tol) in &[(31.5_f64, 1.5), (1000.0, 0.7), (4000.0, 1.6), (8000.0, 2.1)] {
             let got = f.magnitude_db(fr);
             let expected = a_reference_db(fr);
             assert!(
@@ -327,7 +327,7 @@ mod tests {
     #[test]
     fn c_weighting_matches_standard_within_class1_tolerance() {
         let f = WeightingFilter::new(Weighting::C, FS).unwrap();
-        for &(fr, tol) in &[(31.0_f64, 1.5), (1000.0, 0.7), (4000.0, 1.6), (8000.0, 2.1)] {
+        for &(fr, tol) in &[(31.5_f64, 1.5), (1000.0, 0.7), (4000.0, 1.6), (8000.0, 2.1)] {
             let got = f.magnitude_db(fr);
             let expected = c_reference_db(fr);
             assert!(


### PR DESCRIPTION
closes #118

### what changed
Tightened four measurement tests that asserted less than their comments claimed, and reconciled the IEC 61260-1 citations in the filterbank. No production DSP changed — test bodies, one test-helper signature, and doc comments only.

### files touched
- `ac-rs/crates/ac-core/src/measurement/thd.rs` — `wrong_fundamental_returns_error_or_high_thd` had a dead `let _ = result;` (asserted nothing). Now: `Err` (fundamental-energy guard) is an accepted outcome, otherwise `thd_pct` must be > 10 % (vs ~0.01 % for a clean tone). Written as `if let Ok` to avoid a `single_match` clippy lint.
- `ac-rs/crates/ac-core/src/measurement/filterbank.rs` — `class1_neighbour_min_atten_db(_bpo)` ignored its parameter and returned a flat 17.5 dB. Dropped the dead `bpo` parameter (+ call site) and reworded the doc to state plainly this is a **deliberate bpo-independent regression floor**, not the per-band IEC mask. Resolved per acceptance-criteria option (b): IEC 61260-1 §5.10 only tabulates the 1/1- and 1/3-octave cases (Table 1 / Annex F Table F.1), so a genuine per-bpo limit for 6/12/24 would require inventing numbers. Also fixed two bogus citations: the relative-attenuation limits are **§5.10 / Table 1 / Annex F Table F.1**, not "§5.4 Table 2" (§5.4 is *mid-band frequencies* — still correctly cited for the centre-frequency anchor; "Table 2" in the standard is unrelated EMC content).
- `ac-rs/crates/ac-core/src/measurement/weighting.rs` — A- and C-weighting Class-1 tolerance tests evaluated the filter at **31.0 Hz** while comparing against the **31.5 Hz** reference value (−39.4 / −3.0 dB), a mismatch masked by the ±1.5 dB tolerance. Now evaluate at 31.5 Hz.

### test output
```
ac-core   267 passed; 0 failed   (same count — tests fixed, not added)
total     682 passed; 0 failed; 3 ignored
```
`cargo fmt --check` clean (0 diffs). `cargo clippy -- -D warnings`: zero new lints vs `main` (verified by sorted-message diff; pre-existing workspace lints from rust-1.95.0 toolchain drift untouched).

### ZMQ schema changed
no

### new dependencies
none

### related
none

### open questions for reviewer
- **filterbank flat floor (option b vs a):** I kept the 17.5 dB neighbour floor as an explicit, documented regression bound rather than implementing a per-bpo IEC mask, because the standard only tabulates 1/1 and 1/3 octave and the bank also supports 6/12/24. If you'd prefer a genuine per-bpo limit (option a), that needs the Table 1 / F.1 breakpoint values plus a sanctioned extrapolation rule for the narrow bands — happy to do it as a follow-up if you want to define that rule.
- `weighting.rs` comment says "per Table 2" — that's IEC **61672-1** (sound level meters), a different standard than the filterbank's 61260-1, and was not in scope for #118, so I left it. Flag if you want it verified too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)