### PR TITLE
docs: refresh module maps + correct H1/LKFS invariants in specs

### DIFF
--- a/.agents/architect.md
+++ b/.agents/architect.md
@@ -12,29 +12,36 @@ deeply and your job is to make the design decision explicit, not to implement it
 ## repo context
 
 ### module map
+Four-crate Rust workspace under `ac-rs/crates/`; `ARCHITECTURE.md` is
+authoritative.
 ```
-ac/
-  src/
-    main.rs         — entrypoint, ZMQ server setup
-    estimator.rs    — H1 two-channel estimator (Müller-Massarani)
-    session.rs      — session state, exposed via ZMQ pub socket
-    level.rs        — scalar dBu level reference (active)
-    signal.rs       — signal generation and capture
-
-thd_tool/
-  src/
-    main.rs         — entrypoint
-    measure.rs      — THD floor measurement logic
-    report.rs       — result formatting
+ac-core/   — pure DSP library, no binary
+  measurement/  Tier 1 reference: thd.rs (IEC 60268-3), filterbank.rs
+                (IEC 61260-1), weighting.rs (IEC 61672-1), noise.rs (AES17),
+                loudness.rs (BS.1770-5 LKFS), sweep.rs (Farina log-sweep IR),
+                report.rs (HTML/PDF)
+  visualize/    Tier 2 live analysis: transfer.rs (live Welch H1), spectrum,
+                CWT/CQT/reassigned STFT, fractional-octave, time integration
+  shared/       calibration (voltage/SPL/mic-curve), conversions,
+                reference_levels, generator, config, time
+ac-daemon/ — binary `ac-daemon`: ZMQ REP+PUB server, audio I/O
+             (JACK/CPAL/fake), worker management; thin shell over ac-core
+ac-cli/    — binary `ac`: positional parser, ZMQ REQ/SUB, CSV export
+ac-ui/     — binary `ac-ui`: wgpu/egui spectrum/waterfall/transfer views
 ```
 
 ### key invariants
-- The H1 estimator uses a Müller-Massarani windowed cross-correlation approach.
-  Changes to estimator internals must preserve the mathematical correctness of the
-  transfer function estimate.
-- Level reference is a scalar dBu offset — there is no frequency-dependent
-  correction curve (that code was removed; do not reintroduce it).
-- `thd_tool` is standalone. It does not share state with `ac` at runtime.
+- Two transfer-function paths use different math; changes to either must
+  preserve its mathematical correctness:
+  - **Live**: Welch H1 (`ac-core/src/visualize/transfer.rs`) — `Gxy/Gxx`,
+    Hann window, 50 % overlap, with coherence.
+  - **Sweep**: Farina exponential-sweep deconvolution
+    (`ac-core/src/measurement/sweep.rs`, Farina 2000).
+  There is no "Müller-Massarani" estimator in this codebase.
+- The dBu/level reference is a scalar offset (`ac-core/src/shared/`) — there is
+  no frequency-dependent correction curve on it; do not reintroduce one.
+- THD lives in `ac-core/src/measurement/thd.rs`; there is no separate
+  `thd_tool` crate.
 
 ## inputs you will receive
 - The issue body and triage spec comment
@@ -109,17 +116,19 @@ of the normal issue-review flow. Read-only — do not open issues or PRs.
 Read the full source tree. Produce a structured findings report covering:
 
 ### module boundaries
-- Are the two crates (`ac`, `thd_tool`) cleanly separated?
+- Are the four crates (`ac-core`, `ac-daemon`, `ac-ui`, `ac-cli`) cleanly
+  separated — is `ac-core` free of I/O, with the binaries as thin shells?
 - Is there any logic that belongs in one crate but lives in another?
 - Are there any circular or unexpected dependencies?
 
 ### invariant audit
 For each stated invariant, confirm it is actually enforced in code:
-- ZMQ session schema: is the schema definition single-sourced or duplicated?
+- ZMQ frame/session schema: is the schema definition single-sourced or duplicated?
 - Level reference: is there any code path that could introduce frequency-dependent correction?
-- H1 estimator: does the implementation match the Müller-Massarani derivation
-  in `stddocs/iec-full/Simultaneous_Measurement_of_Impulse_Response_and_D.pdf`?
-- `thd_tool` standalone: does it have any runtime coupling to `ac`?
+- Live transfer: does `visualize/transfer.rs` implement Welch H1 (`Gxy/Gxx`,
+  Hann, 50 % overlap, coherence)?
+- Sweep IR: does `measurement/sweep.rs` implement Farina exponential-sweep
+  deconvolution per `stddocs/iec-full/Simultaneous_Measurement_of_Impulse_Response_and_D.pdf`?
 
 ### interface surface
 - What does the ZMQ session schema currently publish? Is it documented anywhere?
@@ -143,8 +152,8 @@ For each stated invariant, confirm it is actually enforced in code:
 |---|---|---|
 | ZMQ schema single-sourced | ✓ / ✗ | |
 | no freq-dependent level ref | ✓ / ✗ | |
-| H1 matches Müller-Massarani | ✓ / ? / ✗ | |
-| thd_tool standalone | ✓ / ✗ | |
+| live transfer is Welch H1 | ✓ / ? / ✗ | |
+| sweep IR is Farina deconvolution | ✓ / ? / ✗ | |
 
 ### interface surface
 {findings}

--- a/.agents/developer.md
+++ b/.agents/developer.md
@@ -12,35 +12,47 @@ You make the change, verify it, and open the PR.
 ## repo context
 
 ### build
+All cargo commands run inside `ac-rs/` (the cargo workspace).
 ```bash
 cargo build                  # full workspace build
 cargo test                   # all tests, all crates
-cargo test -p ac             # single crate
+cargo test -p ac-core        # single crate (ac-core | ac-daemon | ac-ui | ac-cli)
 cargo clippy -- -D warnings  # must be clean before PR
 cargo fmt --check            # must pass (do not reformat unrelated code)
 ```
 
 ### module map
+Four-crate Rust workspace under `ac-rs/crates/`. See `ac-rs/CLAUDE.md` and
+`ARCHITECTURE.md` for the authoritative map.
 ```
-ac/src/
-  main.rs       — ZMQ server, entrypoint
-  estimator.rs  — H1 two-channel estimator
-  session.rs    — session state schema (ZMQ pub)
-  level.rs      — dBu scalar reference
-  signal.rs     — signal gen and capture
-
-thd_tool/src/
-  main.rs       — entrypoint
-  measure.rs    — THD measurement
-  report.rs     — output formatting
+ac-core/   — pure library, no binary. The DSP lives here:
+  measurement/   Tier 1 reference: thd.rs, filterbank.rs, weighting.rs,
+                 noise.rs, loudness.rs, sweep.rs (Farina log-sweep IR), report.rs
+  visualize/     Tier 2 live analysis: transfer.rs (live Welch H1), spectrum,
+                 CWT/CQT/reassigned, fractional-octave, time integration
+  shared/        calibration (voltage/SPL/mic-curve), conversions,
+                 reference_levels, generator, config, time
+ac-daemon/ — binary `ac-daemon`. ZMQ REP+PUB server, audio I/O (JACK/CPAL/fake),
+             worker mgmt. Thin shell over ac-core. (src/handlers/, src/audio/)
+ac-cli/    — binary `ac`. Positional CLI parser, ZMQ REQ/SUB, CSV export.
+ac-ui/     — binary `ac-ui`. wgpu/egui GPU spectrum/waterfall/transfer views.
 ```
 
 ### key invariants — do not break these
-- `ac::level` is a scalar dBu offset only. There is no frequency-dependent
-  correction curve. Do not add one.
-- `ac::estimator` implements the Müller-Massarani H1 approach. Changes to
-  estimator math require architect sign-off (`design-approved` label).
-- `thd_tool` is standalone — no runtime coupling to `ac`.
+- The dBu/level reference is a scalar offset only (`ac-core/src/shared/`,
+  calibration + conversions). There is no frequency-dependent correction curve
+  on the dBu reference. Do not add one.
+- Two transfer-function paths, different math — changes to either require
+  architect sign-off (`design-approved` label):
+  - **Live**: Welch H1 in `ac-core/src/visualize/transfer.rs` — `Gxy/Gxx`,
+    Hann window, 50 % overlap, with coherence.
+  - **Sweep**: Farina exponential-sweep deconvolution in
+    `ac-core/src/measurement/sweep.rs` (Farina 2000). There is no
+    "Müller-Massarani" estimator in this codebase.
+- THD lives in `ac-core/src/measurement/thd.rs` (IEC 60268-3). There is no
+  separate `thd_tool` crate.
+- Loudness is LKFS per ITU-R BS.1770-5 (`ac-core/src/measurement/loudness.rs`),
+  not "LUFS".
 
 ## inputs you will receive
 - Issue number, title, URL

--- a/.agents/qa.md
+++ b/.agents/qa.md
@@ -13,12 +13,14 @@ it is a bug.
 ## repo context
 
 ### what correctness means in this codebase
-- `ac` implements a two-channel H1 estimator (Müller-Massarani). Transfer function
-  estimates must be numerically stable and unbiased given the windowing assumptions.
-- `thd_tool` produces THD figures. Results should be within expected dynamic range
-  for the device under test. Gross outliers (e.g. THD > 10% for a known-good amp)
+- `ac-core` has two transfer-function paths: a live Welch H1 estimator
+  (`visualize/transfer.rs`: `Gxy/Gxx`, Hann window, 50 % overlap, coherence) and
+  a Farina exponential-sweep IR deconvolution (`measurement/sweep.rs`). Estimates
+  must be numerically stable and unbiased given the windowing assumptions.
+- THD (`measurement/thd.rs`) figures should be within expected dynamic range for
+  the device under test. Gross outliers (e.g. THD > 10% for a known-good amp)
   indicate a measurement error in the code.
-- Level reference in `ac` is a scalar dBu offset. Any change that makes it
+- The dBu/level reference is a scalar offset (`shared/`). Any change that makes it
   frequency-dependent is a regression.
 
 ### build and test
@@ -44,7 +46,7 @@ or display units. Do not rely on memory — consult the document.
 | IEC 61260-1:2014 | `stddocs/IEC-61260-1-2014.pdf` | Octave and fractional-octave band filters: bandwidth, ripple, attenuation |
 | IEC 61672-1:2013 | `stddocs/IEC-61672-1-2013.pdf` | Sound level meters: frequency weighting, time weighting, level linearity |
 | ITU-R BS.468-4 | `stddocs/ITU-R BS.468-4.pdf` | Noise measurement: quasi-peak detector, 468 weighting curve |
-| ITU-R BS.1770-5 | `stddocs/ITU-R BS.1770-5.pdf` | Loudness measurement: K-weighting, integrated loudness (LUFS), true-peak |
+| ITU-R BS.1770-5 | `stddocs/ITU-R BS.1770-5.pdf` | Loudness measurement: K-weighting, integrated loudness (LKFS), true-peak |
 
 ### reference reading (non-normative)
 
@@ -55,11 +57,11 @@ Consult them when the standard text is ambiguous or when checking numerical resu
 |---|---|---|
 | Metzler — Audio Measurement Handbook 2nd ed. | `stddocs/pdfcoffee.com_audio-measurement-handbook-2nd-ed-2005-bob-metzler-pdf-free.pdf` | Practical measurement procedures, expected value ranges, instrument behaviour |
 | Fundamentals of Modern Audio Measurement | `stddocs/Fundamentals_of_modern_audio_measurement.pdf` | Estimator theory, windowing, FFT measurement fundamentals |
-| Müller & Massarani 2001 | `stddocs/iec-full/Simultaneous_Measurement_of_Impulse_Response_and_D.pdf` | H1 estimator derivation — primary reference for `ac/src/estimator.rs` |
+| Farina 2000 | `stddocs/iec-full/Simultaneous_Measurement_of_Impulse_Response_and_D.pdf` | Exponential-sweep IR + distortion deconvolution — primary reference for `ac-core/src/measurement/sweep.rs` |
 
 ### how to use them during review
 
-**AES-17** is the primary normative reference for `thd_tool`. When reviewing, read the
+**AES-17** is the primary normative reference for THD (`ac-core/src/measurement/thd.rs`). When reviewing, read the
 relevant clause — do not rely on paraphrase. Check:
 - THD+N residual is computed after fundamental removal, not as ratio to total RMS
 - Measurement bandwidth is explicitly stated or matches the standard default
@@ -89,8 +91,9 @@ digital I/O, sampling, or dithering, use the 2020 document.
 - Weighting curve identified in output if not unweighted
 
 **ITU-R BS.1770-5** applies if integrated loudness or true-peak values appear. Check:
-- Integrated loudness expressed as `LUFS` (not `LKFS` — both are used in the wild
-  but LUFS is the current preferred term per BS.1770-5 §3)
+- Integrated loudness expressed as `LKFS` — the unit BS.1770-5 actually
+  prescribes (the code uses LKFS). `LUFS` is the EBU/R128 synonym seen in the
+  wild; do not "correct" the code's LKFS to LUFS.
 - True-peak expressed as `dBTP`, not `dBFS`
 - Gating behaviour (absolute and relative gates) matches §2.7 if implemented
 
@@ -203,12 +206,13 @@ For each module, list:
 - Any tests that assert too weakly (runs without panic vs. asserts a value)
 
 Pay particular attention to:
-- Numerical results from `ac::estimator` and `thd_tool::measure` — are
-  the assertions tight enough to catch a wrong normalization factor?
+- Numerical results from `visualize::transfer` (Welch H1), `measurement::sweep`
+  (Farina IR), and `measurement::thd` — are the assertions tight enough to catch
+  a wrong normalization factor?
 - Error paths — are hardware fault conditions tested at all?
 
 ### standards conformance scan
-For each output value in `ac` and `thd_tool`, check against the
+For each output value in `ac-core` (measurement + visualize), check against the
 applicable standard from `stddocs/` (use the standards table in this spec).
 Flag any value that is:
 - computed correctly but labelled incorrectly
@@ -225,15 +229,15 @@ use `? — needs verification` for anything requiring deeper analysis.
 ### test coverage map
 | module | what is tested | what is missing | weak assertions |
 |---|---|---|---|
-| ac::estimator | ... | ... | ... |
-| ac::session | | | |
-| thd_tool::measure | | | |
-| thd_tool::report | | | |
+| visualize::transfer (Welch H1) | ... | ... | ... |
+| measurement::sweep (Farina IR) | | | |
+| measurement::thd | | | |
+| measurement::loudness | | | |
 
 ### standards conformance
-| output value | tool | standard | clause | status | notes |
+| output value | module | standard | clause | status | notes |
 |---|---|---|---|---|---|
-| THD+N % | thd_tool | AES-17-2015 | §6.3 | ✓ / ✗ / ? | |
+| THD+N % | measurement::thd | AES-17-2015 | §6.3 | ✓ / ✗ / ? | |
 
 ### critical gaps
 {Test coverage or standards issues that could cause a measurement to be

--- a/.agents/triage.md
+++ b/.agents/triage.md
@@ -9,12 +9,16 @@ You are a product manager, not an engineer. You think about what needs to happen
 and why — not how. You do not write code.
 
 ## repo context
-- `ac/` — ZMQ server/client audio measurement tool. Two-channel H1 estimator,
-  Müller-Massarani framework. Has a running session state exposed via ZMQ.
-- `thd_tool/` — THD measurement. Generates test signals, captures and processes results.
+Four-crate Rust workspace under `ac-rs/crates/` (see `ARCHITECTURE.md`):
+- `ac-core` — pure DSP library. Tier 1 `measurement/` (THD, filterbank,
+  weighting, noise, BS.1770-5 loudness, Farina sweep IR) and Tier 2
+  `visualize/` (live Welch H1 transfer, spectrum, CWT/CQT/reassigned).
+- `ac-daemon` — binary `ac-daemon`: ZMQ REP+PUB server, audio I/O, workers.
+- `ac-cli` — binary `ac`: CLI client.
+- `ac-ui` — binary `ac-ui`: GPU spectrum/waterfall/transfer views.
 
-Key architectural constraint: `ac` exposes a ZMQ wire protocol. Changes to that
-protocol affect any consumer. Flag this when relevant.
+Key architectural constraint: `ac-daemon` exposes a ZMQ wire protocol. Changes
+to that protocol affect any consumer. Flag this when relevant.
 
 ## inputs you will receive
 - A GitHub issue (title, body, any existing comments)
@@ -26,8 +30,8 @@ protocol affect any consumer. Flag this when relevant.
 Determine which category it falls into:
 - **bug** — something is broken or produces wrong results
 - **feature** — new capability requested
-- **measurement-accuracy** — relates to H1 estimator, THD floor, windowing, calibration
-- **output-format** — any change to what `ac` or `thd_tool` prints to stdout
+- **measurement-accuracy** — relates to the transfer estimators (Welch H1 / Farina sweep), THD floor, windowing, calibration
+- **output-format** — any change to what `ac` / `ac-ui` prints or displays
 - **infrastructure** — build system, CI, tooling, dependencies
 - **docs** — documentation gap
 
@@ -78,7 +82,7 @@ Always apply exactly one category label:
 
 Then apply the routing label:
 - If needs architect review → `needs-design`
-- If touches any output format, display field, or CLI output of `ac` or `thd_tool` → `needs-ux`
+- If touches any output format, display field, or CLI/UI output of `ac` or `ac-ui` → `needs-ux`
   (this is not optional — `ac` CLI output has a standing design requirement, see `ux.md`)
 - Otherwise → `ready-to-implement`
 

--- a/.agents/ux.md
+++ b/.agents/ux.md
@@ -19,7 +19,7 @@ is a design failure. A number shown without the context that gives it meaning
 is a design failure.
 
 You work across CLI output, terminal TUI elements, log formatting, and any
-future graphical output from `ac` and `thd_tool`. Your medium is
+future graphical output from `ac` and `ac-ui`. Your medium is
 mostly text and character graphics. That is not a constraint — it is the material.
 
 ## aesthetic principles
@@ -58,9 +58,9 @@ verbosity — it is precision.
 ## repo context
 
 ### output surfaces
-- `ac` — terminal output: live session state, level readings, H1 estimate
-  progress, error conditions.
-- `thd_tool` — terminal output: THD+N result, measurement conditions, noise floor
+- `ac` (ac-cli) — terminal output: measurement progress, level readings,
+  frequency-response and THD+N rows, transfer/H1 status, error conditions.
+- `ac-ui` — GPU spectrum / waterfall / transfer views (wgpu/egui).
 
 ### character graphics available
 Unicode block elements, Braille patterns, box-drawing characters. Use them
@@ -224,14 +224,14 @@ ZMQ schema or only in a display layer}
 When invoked with "audit the codebase as ux", do the following instead of
 the normal issue-review flow. Read-only — do not open issues or PRs.
 
-Read all stdout-producing code paths across `ac` and `thd_tool`.
+Read all stdout-producing code paths across `ac` (ac-cli) and `ac-ui`.
 This means: every `println!`, `eprintln!`, format string, and any output
 helper functions. Produce a structured findings report.
 
 ### what to look for
 
 **consistency across tools**
-- Do `ac` and `thd_tool` use the same conventions for labels,
+- Do `ac` and `ac-ui` use the same conventions for labels,
   units, decimal places, and field alignment?
 - Are timestamp formats consistent?
 - Are error messages written in the same register?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,5 +4,6 @@ Agent specs are in `.agents/`. Before doing anything, read the relevant spec
 for your current role. The active role for this session will be stated in the
 first user message.
 
-Repo structure: ac/ thd_tool/ stddocs/
-Build: cargo test | cargo clippy -- -D warnings | cargo fmt --check
+Repo structure: ac-rs/ (cargo workspace: ac-core, ac-daemon, ac-ui, ac-cli) — stddocs/ docs/ tests/
+Build (run in ac-rs/): cargo test | cargo clippy -- -D warnings | cargo fmt --check
+See ac-rs/CLAUDE.md and ARCHITECTURE.md for the crate/module map.


### PR DESCRIPTION
closes #113

### what changed
Brought the root `CLAUDE.md` and the five `.agents/` operating specs in line with the real codebase: the fictional `ac/src/estimator.rs` + `thd_tool/` module maps are replaced with the actual four-crate `ac-rs/` workspace, and two wrong invariants (H1 attribution, LUFS-preferred) are corrected against the code. `ARCHITECTURE.md` and `ac-rs/CLAUDE.md` were already accurate and untouched.

### files touched
- `CLAUDE.md` — repo-structure line now describes `ac-rs/` (the 4-crate workspace) + `stddocs/ docs/ tests/`; build commands run in `ac-rs/`; points at `ac-rs/CLAUDE.md` / `ARCHITECTURE.md` for the map.
- `.agents/developer.md`, `.agents/architect.md` — module maps rewritten to `ac-core` / `ac-daemon` / `ac-ui` / `ac-cli` with real module paths; invariant tables corrected; `cargo test -p ac` → `-p ac-core`.
- `.agents/qa.md` — "what correctness means" + standards/coverage tables fixed; LUFS-preferred claim corrected; Farina reference relabelled.
- `.agents/triage.md` — repo-context crate list + category descriptions refreshed.
- `.agents/ux.md` — output surfaces now `ac` (ac-cli) + `ac-ui` instead of `ac` + `thd_tool`.

### how each acceptance criterion was met
- **Module map → real 4-crate layout:** done. *Deviation, flagged below:* the issue text said "4-crate + standalone Python `ds/`", but `ds/` was removed in #119 (merged). I refreshed to the ds-free reality rather than re-introduce a dead reference.
- **H1 invariant reworded:** live path = Welch H1 (`ac-core/src/visualize/transfer.rs`, `Gxy/Gxx`, Hann, 50 % overlap, coherence); sweep path = Farina exp-sweep deconvolution (`ac-core/src/measurement/sweep.rs`, Farina 2000). Verified against the code before writing.
- **No Müller/Massarani attribution:** removed everywhere; only explicit "there is no Müller-Massarani estimator" disclaimers remain. The reference-reading row that pointed the Farina PDF at a fictional `estimator.rs` is relabelled "Farina 2000 → `measurement/sweep.rs`".
- **LUFS → LKFS (qa-spec):** the "LUFS is the preferred term per BS.1770-5 §3" claim is corrected — BS.1770-5 prescribes **LKFS** (the code uses LKFS); LUFS noted as the EBU/R128 synonym.
- **THD path:** all specs now point at `ac-core/src/measurement/thd.rs`; no `thd_tool` crate.

### test output
```
docs-only change — no .rs files touched. Workspace unaffected:
total 682 passed; 0 failed; 3 ignored
```

### ZMQ schema changed
no

### new dependencies
none

### related
- Depended-on cleanup #119 (ds removal) and #120 (timestamps) are merged; this reconciles the docs with that reality.

### open questions for reviewer
- **Stale issue spec (criterion 1):** #113 predates the #119 ds-drop and asked to keep `ds/` in the map. I dropped it instead (ds no longer exists). Flag if you want it re-added (you don't).
- **`docs/loudness-bs1770-5.md`** uses `−70 LUFS` / `−23 LUFS` for the EBU R128 gate/target. That's conventional R128 usage, not the false "LUFS-preferred" claim, so I left it. Say if you want those switched to LKFS too.
- Did **not** touch `loudness.rs` / `overlay.rs` — code correctly uses LKFS; #113 scopes out estimator/code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)