### PR TITLE
refactor: standardise dmm Vrms precision to 4 dp via shared formatter

### DIFF
--- a/ac-rs/crates/ac-cli/src/commands/dmm.rs
+++ b/ac-rs/crates/ac-cli/src/commands/dmm.rs
@@ -14,15 +14,10 @@ pub fn run(client: &mut AcClient) {
         .and_then(|v| v.as_f64())
         .unwrap_or(0.0);
     let dbu = ac_core::shared::conversions::vrms_to_dbu(vrms);
-    let vpp = vrms * 2.0 * std::f64::consts::SQRT_2;
 
-    if vrms >= 1.0 {
-        println!("\n  AC  {vrms:.6} Vrms  =  {dbu:+.2} dBu  =  {vpp:.4} Vpp\n");
-    } else {
-        println!(
-            "\n  AC  {:.4} mVrms  =  {dbu:+.2} dBu  =  {:.4} mVpp\n",
-            vrms * 1000.0,
-            vpp * 1000.0
-        );
-    }
+    println!(
+        "\n  AC  {}  =  {dbu:+.2} dBu  =  {}\n",
+        ac_core::shared::conversions::fmt_vrms(vrms),
+        ac_core::shared::conversions::fmt_vpp(vrms)
+    );
 }


### PR DESCRIPTION
closes #131

### what changed
`ac dmm` rendered Vrms at 6 dp via a hand-rolled format branch. Replaced that branch with `ac_core::shared::conversions::fmt_vrms` / `fmt_vpp`, the same single-source formatters already used by `generate`, `io`, and `calibrate`. dBu still via `vrms_to_dbu`. Vrms ≥1 V now prints 4 dp (decision locked in spec); the manual `vrms*2*√2` Vpp calc is gone in favour of `fmt_vpp`.

### files touched
- `crates/ac-cli/src/commands/dmm.rs` — drop manual mVrms/Vrms/Vpp format branch; route through `fmt_vrms`/`fmt_vpp`.

### test output
```
cargo test -p ac-cli
test result: ok. 80 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### ZMQ schema changed
no

### new dependencies
none

### related
none

### open questions for reviewer
- `fmt_vrms` emits **3 dp** for the sub-1 V (mVrms) case, whereas the old dmm branch (and `setup.rs:119`) use **4 dp** for mVrms. Routing dmm through the shared formatter therefore changes dmm's mV display from 4→3 dp and Vpp via `fmt_vpp` (2 dp mVpp / 4 dp Vpp). The spec's locked decision and before/after only cover the ≥1 V Vrms case; using the single-source formatter is the explicit instruction, so I took it for the whole output. If 4 dp mVrms must be preserved, that belongs in `fmt_vrms` itself (affects all callers) — flagging rather than special-casing dmm.
- Pre-existing, out of scope: `cargo clippy -- -D warnings` and `cargo fmt --check` both fail on `main` (12 clippy errors in `ac-core`, fmt drift across several `ac-cli` files). Not touched. `dmm.rs` itself is fmt-clean and adds no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)