### PR TITLE
feat: show THD/THD+N as dB re fundamental, fix unit spacing

### DIFF
--- a/ac-rs/crates/ac-cli/src/io.rs
+++ b/ac-rs/crates/ac-cli/src/io.rs
@@ -44,6 +44,20 @@ pub fn save_csv(results: &[serde_json::Value], path: &Path) {
     println!("  CSV  -> {}", path.display());
 }
 
+/// THD/THD+N percent expressed as dB relative to the fundamental.
+///
+/// `dB = 20·log10(pct/100)`. Percent compresses the interesting region near
+/// the floor; the dB-re-fundamental form is linear in the floor and is the
+/// meaningful engineering figure. Returns `-` for a non-positive percent (no
+/// valid measurement), where the dB form is undefined.
+fn thd_db_re_fund(pct: f64) -> String {
+    if pct > 0.0 {
+        format!("{:.1}", 20.0 * (pct / 100.0).log10())
+    } else {
+        "-".to_string()
+    }
+}
+
 pub fn print_summary(results: &[serde_json::Value], device_name: &str, have_cal: bool) {
     if results.is_empty() {
         return;
@@ -99,14 +113,23 @@ pub fn print_summary(results: &[serde_json::Value], device_name: &str, have_cal:
     if ac_n > 0 {
         println!("  AC-coupled pts:   {ac_n}  (excluded -- coupling cap rolloff)");
     }
-    println!("  Worst THD:        {worst_thd:.4}%");
-    println!("  Worst THD+N:      {worst_thdn:.4}%");
+    println!(
+        "  Worst THD:        {worst_thd:.4} %    {} dB re fund",
+        thd_db_re_fund(worst_thd)
+    );
+    println!(
+        "  Worst THD+N:      {worst_thdn:.4} %    {} dB re fund",
+        thd_db_re_fund(worst_thdn)
+    );
     let note = if clipped_n > 0 || ac_n > 0 {
         "  (valid points only)"
     } else {
         ""
     };
-    println!("  Average THD:      {avg_thd:.4}%{note}");
+    println!(
+        "  Average THD:      {avg_thd:.4} %    {} dB re fund{note}",
+        thd_db_re_fund(avg_thd)
+    );
 
     if have_cal {
         let lo = results.first().and_then(|r| r.get("out_vrms")).and_then(|v| v.as_f64());
@@ -225,12 +248,34 @@ pub fn print_freq_row(frame: &serde_json::Value) {
         let gain_s = frame
             .get("gain_db")
             .and_then(|v| v.as_f64())
-            .map(|v| format!("{v:+.2}dB"))
+            .map(|v| format!("{v:+.2} dB"))
             .unwrap_or_else(|| "  -".into());
         println!(
             "  {freq:>7.0} Hz  {out_s:>12}  {odbu:>8}  {in_s:>12}  {idbu:>8}  {gain_s:>8}  {thd:>9.4}  {thdn:>9.4}{flag}"
         );
     } else {
         println!("  {freq:>7.0} Hz  {thd:>9.4}  {thdn:>9.4}{flag}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thd_db_re_fund_matches_formula() {
+        // 100% THD is the fundamental itself -> 0 dB re fund.
+        assert_eq!(thd_db_re_fund(100.0), "0.0");
+        // 1% -> 20*log10(0.01) = -40 dB.
+        assert_eq!(thd_db_re_fund(1.0), "-40.0");
+        // Spec example: 0.0042% -> -87.5 dB re fund (1 decimal).
+        assert_eq!(thd_db_re_fund(0.0042), "-87.5");
+    }
+
+    #[test]
+    fn thd_db_re_fund_dash_for_non_positive() {
+        // dB form is undefined for a non-positive percent (no valid point).
+        assert_eq!(thd_db_re_fund(0.0), "-");
+        assert_eq!(thd_db_re_fund(-1.0), "-");
     }
 }


### PR DESCRIPTION
closes #128

### what changed
THD/THD+N were displayed as percent only, which compresses the interesting region near the noise floor. Added a `dB re fund` companion (`dB = 20·log10(pct/100)`) to the summary THD-family rows (Worst THD, Worst THD+N, Average THD) and fixed the missing space before the `%` and `dB` units. The percent→dB conversion is a pure client-side display helper, so no `ac-core` API change.

### files touched
- `ac-rs/crates/ac-cli/src/io.rs` — new `thd_db_re_fund()` display helper; summary rows now print `0.0042 %    -87.5 dB re fund` with correct unit spacing; freq-row gain now `+1.50 dB` (was `+1.50dB`); 2 unit tests for the helper.

### test output
```
cargo test -p ac-cli --all-targets
running 82 tests
test result: ok. 82 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
(includes 2 new tests: `thd_db_re_fund_matches_formula`, `thd_db_re_fund_dash_for_non_positive`)

### ac-daemon IPC schema changed
no

### new dependencies
none

### related
none

### open questions for reviewer
- **Pre-existing repo-wide fmt/clippy drift (NOT from this PR).** Under the local toolchain (rust/clippy 1.95), `origin/main` already fails both `cargo fmt --check` (50+ files across ac-core + ac-cli) and `cargo clippy -- -D warnings` (14 warnings, e.g. `map_or`→`is_some_and`, `needless_borrows`). None originate from this change — my added lines pass `rustfmt --check` and add zero clippy warnings. I did **not** reformat/fix those files (out of scope, would bundle unrelated changes). The QA fmt/clippy gate will be red on this pre-existing drift; recommend a separate toolchain-bump/format-sweep issue to address it repo-wide.
- **Scope boundary vs #116.** Per the triage coordination note, this PR touches only the THD-family rows. I left the freq-result table (`THD%`/`THD+N%` headers, column order, per-cell `%`) untouched — that table restructure belongs to #116/#127. The proposed table layout in the spec is therefore intentionally out of scope here.
- I added the `dB re fund` companion to **all three** summary THD rows (incl. Average THD) for consistency; the spec's proposed output only illustrated the two Worst rows. Easy to drop from Average if you prefer it match the mockup exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)