### PR TITLE
fix: monitor tui floor as dBFS with 1 decimal

### DIFF
--- a/ac-rs/crates/ac-cli/src/commands/monitor_tui.rs
+++ b/ac-rs/crates/ac-cli/src/commands/monitor_tui.rs
@@ -98,9 +98,9 @@ fn format_channel_row(s: &ChannelStats) -> String {
         "      -- Hz".to_string()
     };
     let floor = if s.floor_db.is_finite() {
-        format!("{:>5.0} dB", s.floor_db)
+        format!("{:>7.1} dBFS", s.floor_db)
     } else {
-        "   -- dB".to_string()
+        "     -- dBFS".to_string()
     };
     format!(
         "CH{:<2}   peak {} @ {}   floor {}",
@@ -313,7 +313,7 @@ mod tests {
         assert!(out.contains("CH0"));
         assert!(out.contains("-3.0 dBFS"));
         assert!(out.contains("1000 Hz"));
-        assert!(out.contains("-85 dB"));
+        assert!(out.contains("-85.0 dBFS"));
         assert!(out.contains("fft N=8192"));
         assert!(out.contains("interval=100 ms"));
         assert!(out.contains("xruns=0"));


### PR DESCRIPTION
closes #134

### what changed
The `ac monitor` tui floor field was printed as a bare `dB` at zero decimals (`{:>5.0} dB`), which dropped the reference and erased sub-dB drift. Changed it to `{:>7.1} dBFS` so it carries the dBFS reference and 1 decimal — matching the peak field already on the same row. Widened the no-data placeholder to the same field width.

### files touched
- `ac-rs/crates/ac-cli/src/commands/monitor_tui.rs` — floor render format `{:>5.0} dB` → `{:>7.1} dBFS`; `--` placeholder widened; updated the render test assertion from `-85 dB` to `-85.0 dBFS`.

### test output
```
cargo test -p ac-cli: ok. 82 passed; 0 failed; 0 ignored
```

### ac-daemon IPC schema changed
no

### new dependencies
none

### related
none

### open questions for reviewer
- **Pre-existing workspace lint/fmt failures, not from this PR.** `cargo clippy -- -D warnings` and `cargo fmt --check` currently FAIL on `main` (HEAD `4062aee`) — `ac-core` has 11 clippy errors and several files carry rustfmt drift under the pinned 1.95.0 toolchain. The clean baseline commit (`f62b3b1`, "toolchain sweep") lives on the in-flight #136 branch and is **not yet merged to main**. This PR's diff is limited to the two floor lines + one test assertion; the edited lines are fmt-clean and add no new clippy findings. The pre-existing drift in unrelated lines of this same file (51/180/262) is owned by #136 — left untouched to avoid churn/conflict with that sweep.