### PR TITLE
feat: dual-resolution low-frequency spectrum for ac-ui monitor

### DIFF
--- a/ac-rs/ZMQ.md
+++ b/ac-rs/ZMQ.md
@@ -1078,12 +1078,18 @@ all drawn from the same live port.
 **Reply**
 ```json
 {
-  "ok":       true,
-  "in_port":  "<primary-port>",   // first channel — kept for backward compat
-  "in_ports": ["<port>", ...],    // resolved port per entry in `channels`
-  "channels": [<int>, ...]        // echoed channel indices (defaulted if absent)
+  "ok":           true,
+  "in_port":      "<primary-port>", // first channel — kept for backward compat
+  "in_ports":     ["<port>", ...],  // resolved port per entry in `channels`
+  "channels":     [<int>, ...],     // echoed channel indices (defaulted if absent)
+  "lf_fft_n":     <int>,            // dual-resolution low-band FFT N (see below)
+  "crossover_hz": <float>           // LF/HF split frequency (daemon-owned constant)
 }
 ```
+
+`lf_fft_n` and `crossover_hz` are daemon-owned constants for the
+dual-resolution low-frequency path (see below). They are read-only and
+echoed so the UI can label the LF band without hardcoding daemon values.
 
 **DATA** — repeated until stopped (spectrum frame, see Shared types).
 
@@ -1114,10 +1120,49 @@ Request/reply is synchronous on the REP socket; no frames emitted.
 
 **Reply**
 ```json
-{ "ok": true,  "interval": <float>, "fft_n": <int> }
+{ "ok": true,  "interval": <float>, "fft_n": <int>, "lf_fft_n": <int>, "crossover_hz": <float> }
 { "ok": false, "error": "no active monitor" }
 { "ok": false, "error": "fft_n must be power of 2 in [256, 131072]" }
 ```
+
+`lf_fft_n` / `crossover_hz` are echoed read-only (the UI cannot set them);
+only `interval` and `fft_n` are user-tunable.
+
+---
+
+### Dual-resolution low-frequency path (#142)
+
+Linear FFT bins are equally spaced, so the bottom octaves get few bins and
+closely-spaced low tones smear together. To split tones ~5 Hz apart below
+100 Hz you need `Δf ≲ 2.5 Hz`, i.e. `N ≥ 32768` at 48 kHz — but applying that
+window to the whole band would add ~1.4 s of latency everywhere and smear
+mid/high transients.
+
+Instead the FFT monitor runs a **second, longer** FFT (`lf_fft_n`, default
+65536 ≈ 0.73 Hz Δf at 48 kHz) over the same capture ring and uses it **only
+below `crossover_hz`** (default 750 Hz). The live `fft_n` keeps driving
+everything above the crossover at the normal refresh rate. The two linear
+half-spectra are merged into the single log-column `spectrum` wire frame
+(`spectrum_to_columns_multiband`), cross-faded linearly in dB across a
+±1/6-octave band at the crossover so the splice is seamless. **The wire frame
+shape is unchanged** — subscribers need no changes.
+
+Resolution / trade-off the user gets:
+
+- **Below `crossover_hz`:** `Δf = sr / lf_fft_n` (≈ 0.73 Hz at 48 kHz),
+  enough to separate 5 Hz-spaced tones under 100 Hz. The LF band inherently
+  refreshes at the long-block rate (`lf_fft_n / sr` ≈ 1.4 s) — acceptable
+  because LF content is slow-moving. The long FFT is recomputed at most once
+  per block duration to bound CPU.
+- **Above `crossover_hz`:** unchanged — `Δf = sr / fft_n` at the live refresh
+  rate, so mid/high responsiveness is not degraded.
+
+The LF path is **inactive** whenever `fft_n >= lf_fft_n` (the live spectrum is
+already at least as fine), in which case the monitor behaves exactly as
+before. Peak detection (`peaks` field) uses the LF spectrum below the
+crossover and the live spectrum above it. The UI's top-right readout shows
+both resolutions on two lines, each scoped by the crossover, when the LF path
+is active.
 
 ---
 

--- a/ac-rs/crates/ac-core/src/visualize/aggregate.rs
+++ b/ac-rs/crates/ac-core/src/visualize/aggregate.rs
@@ -86,12 +86,27 @@ pub fn spectrum_to_columns(
     out
 }
 
+/// Per-column centre frequencies for a log-spaced display of `n_columns`
+/// columns between `f_min` and `f_max`. Shared by the `_wire` helpers so
+/// the magnitudes and the axis they ship alongside always agree. Returns
+/// an empty vec for degenerate input.
+// Negated `>` comparisons are intentional NaN-aware guards.
+#[allow(clippy::neg_cmp_op_on_partial_ord)]
+fn column_centre_freqs(f_min: f64, f_max: f64, n_columns: usize) -> Vec<f64> {
+    if n_columns == 0 || !(f_min > 0.0) || !(f_max > f_min) {
+        return Vec::new();
+    }
+    let log_ratio = (f_max / f_min).ln();
+    let n = n_columns as f64;
+    (0..n_columns)
+        .map(|i| f_min * (log_ratio * (i as f64 + 0.5) / n).exp())
+        .collect()
+}
+
 /// Wire-format helper: aggregate an `f64` linear half-spectrum into a log-
 /// frequency representation suitable for ZMQ publish. Returns `(magnitudes,
 /// frequencies)` both as `Vec<f64>`, log-spaced between `f_min` and `f_max`.
 /// Frequencies are per-column centres so axis labels align with the data.
-// Negated `>` comparisons are intentional NaN-aware guards (see above).
-#[allow(clippy::neg_cmp_op_on_partial_ord)]
 pub fn spectrum_to_columns_wire(
     spectrum_db: &[f64],
     sr: f64,
@@ -102,15 +117,107 @@ pub fn spectrum_to_columns_wire(
     let spec32: Vec<f32> = spectrum_db.iter().map(|&v| v as f32).collect();
     let cols32 = spectrum_to_columns(&spec32, sr as f32, f_min as f32, f_max as f32, n_columns);
     let cols64: Vec<f64> = cols32.iter().map(|&v| v as f64).collect();
-    let freqs64: Vec<f64> = if n_columns == 0 || !(f_min > 0.0) || !(f_max > f_min) {
-        Vec::new()
-    } else {
-        let log_ratio = (f_max / f_min).ln();
-        let n = n_columns as f64;
-        (0..n_columns)
-            .map(|i| f_min * (log_ratio * (i as f64 + 0.5) / n).exp())
-            .collect()
-    };
+    let freqs64 = column_centre_freqs(f_min, f_max, n_columns);
+    (cols64, freqs64)
+}
+
+/// Default crossover (Hz) splitting the long-FFT low band from the live
+/// short-FFT high band in the dual-resolution monitor (#142). Chosen in a
+/// typically quiet region so the splice blend is rarely on top of a strong
+/// tone. The daemon owns this value and ships it to the UI so labels never
+/// hardcode it.
+pub const DEFAULT_LF_CROSSOVER_HZ: f32 = 750.0;
+
+/// Half-width of the linear-in-dB blend band around the crossover, in
+/// octaves. The two source spectra are cross-faded across
+/// `[crossover / 2^OCT, crossover * 2^OCT]` so the splice has no visible
+/// step or doubled peak.
+const BLEND_HALF_OCTAVE: f32 = 1.0 / 6.0;
+
+/// Merge two linear half-spectra of the **same** signal — a long-N low-
+/// frequency spectrum (`lf_spectrum`) and a short-N high-frequency one
+/// (`hf_spectrum`) — into a single log-column set (#142).
+///
+/// Below `crossover_hz` the finer `lf_spectrum` supplies each column;
+/// above it the live `hf_spectrum` does; across a ±`BLEND_HALF_OCTAVE`
+/// octave transition band the two are cross-faded linearly in dB so the
+/// splice is seamless. Each band reuses [`spectrum_to_columns`] so the
+/// max-per-column (peak-preserving) and log-interpolation behaviour is
+/// identical to the single-FFT path.
+///
+/// Both spectra must share the same amplitude convention (peak-normalized,
+/// N-independent — see `spectrum_only`). When `lf_spectrum` is unusable or
+/// the crossover is out of band, this degrades to pure `hf_spectrum`
+/// columns.
+// Negated `>` comparison is an intentional NaN-aware guard.
+#[allow(clippy::neg_cmp_op_on_partial_ord)]
+pub fn spectrum_to_columns_multiband(
+    lf_spectrum: &[f32],
+    hf_spectrum: &[f32],
+    sr: f32,
+    crossover_hz: f32,
+    f_min: f32,
+    f_max: f32,
+    n_columns: usize,
+) -> Vec<f32> {
+    if n_columns == 0 {
+        return Vec::new();
+    }
+    let hf = spectrum_to_columns(hf_spectrum, sr, f_min, f_max, n_columns);
+    if lf_spectrum.len() < 2 || !(crossover_hz > f_min) {
+        return hf;
+    }
+    let lf = spectrum_to_columns(lf_spectrum, sr, f_min, f_max, n_columns);
+
+    let blend = 2.0_f32.powf(BLEND_HALF_OCTAVE);
+    let lo = crossover_hz / blend;
+    let hi = crossover_hz * blend;
+    let log_ratio = (f_max / f_min).ln();
+    let n = n_columns as f32;
+    let col_centre = |i: usize| f_min * (log_ratio * (i as f32 + 0.5) / n).exp();
+
+    let mut out = Vec::with_capacity(n_columns);
+    for i in 0..n_columns {
+        let c = col_centre(i);
+        let v = if c <= lo {
+            lf[i]
+        } else if c >= hi {
+            hf[i]
+        } else {
+            let t = (c.ln() - lo.ln()) / (hi.ln() - lo.ln());
+            lf[i] * (1.0 - t) + hf[i] * t
+        };
+        out.push(v);
+    }
+    out
+}
+
+/// Wire-format dual-resolution merge: [`spectrum_to_columns_multiband`]
+/// over `f64` half-spectra, returning `(magnitudes, frequencies)` ready
+/// for ZMQ publish. The frequency axis is identical to
+/// [`spectrum_to_columns_wire`], so the wire frame shape is unchanged.
+pub fn spectrum_to_columns_multiband_wire(
+    lf_spectrum_db: &[f64],
+    hf_spectrum_db: &[f64],
+    sr: f64,
+    crossover_hz: f64,
+    f_min: f64,
+    f_max: f64,
+    n_columns: usize,
+) -> (Vec<f64>, Vec<f64>) {
+    let lf32: Vec<f32> = lf_spectrum_db.iter().map(|&v| v as f32).collect();
+    let hf32: Vec<f32> = hf_spectrum_db.iter().map(|&v| v as f32).collect();
+    let cols32 = spectrum_to_columns_multiband(
+        &lf32,
+        &hf32,
+        sr as f32,
+        crossover_hz as f32,
+        f_min as f32,
+        f_max as f32,
+        n_columns,
+    );
+    let cols64: Vec<f64> = cols32.iter().map(|&v| v as f64).collect();
+    let freqs64 = column_centre_freqs(f_min, f_max, n_columns);
     (cols64, freqs64)
 }
 
@@ -218,5 +325,110 @@ mod tests {
         let cols = spectrum_to_columns(&[], 48000.0, 20.0, 20000.0, 100);
         assert_eq!(cols.len(), 100);
         assert!(cols.iter().all(|v| *v == f32::NEG_INFINITY));
+    }
+
+    /// Two 5 Hz-spaced tones below 100 Hz resolve as separate peaks when
+    /// supplied by a long-N LF spectrum, while a short-N HF spectrum (too
+    /// coarse to split them on its own) drives everything above the
+    /// crossover (#142, acceptance criterion #1).
+    #[test]
+    fn close_tones_resolve_multiband() {
+        let sr = 48_000.0_f32;
+        let crossover = 750.0_f32;
+
+        // LF: long FFT (N=65536) → Δf ≈ 0.73 Hz. Two tones 5 Hz apart at
+        // 60 / 65 Hz, well below the crossover.
+        let lf_len = 65536 / 2 + 1;
+        let lf_df = sr / 65536.0;
+        let mut lf = vec![-180.0_f32; lf_len];
+        lf[(60.0 / lf_df).round() as usize] = 0.0;
+        lf[(65.0 / lf_df).round() as usize] = 0.0;
+
+        // HF: short FFT (N=8192) → Δf ≈ 5.86 Hz, can't split 60/65 Hz.
+        let hf_len = 8192 / 2 + 1;
+        let hf = vec![-180.0_f32; hf_len];
+
+        let n_cols = 1920;
+        let cols = spectrum_to_columns_multiband(&lf, &hf, sr, crossover, 20.0, 20000.0, n_cols);
+
+        let decade = (20000.0_f32 / 20.0).log10();
+        let col_freq = |i: usize| 20.0_f32 * 10f32.powf(decade * (i as f32 + 0.5) / n_cols as f32);
+        let window: Vec<(usize, f32)> = (0..cols.len())
+            .filter(|&i| {
+                let f = col_freq(i);
+                (50.0..=75.0).contains(&f)
+            })
+            .map(|i| (i, cols[i]))
+            .collect();
+
+        let mut maxima: Vec<(usize, f32)> = Vec::new();
+        for w in window.windows(3) {
+            if w[1].1 > w[0].1 && w[1].1 > w[2].1 && w[1].1 > -20.0 {
+                maxima.push(w[1]);
+            }
+        }
+        assert!(
+            maxima.len() >= 2,
+            "expected two distinct LF maxima in 50-75 Hz, got {maxima:?}",
+        );
+        assert!(
+            maxima.windows(2).any(|p| p[1].0 > p[0].0 + 2),
+            "LF maxima adjacent, no dip between them: {maxima:?}",
+        );
+    }
+
+    /// Above the crossover the HF spectrum's narrow peak survives the merge
+    /// unchanged — LF augmentation must not degrade mid/high rendering
+    /// (#142, acceptance criterion #2).
+    #[test]
+    fn multiband_preserves_hf_peak() {
+        let sr = 96_000.0_f32;
+        let hf_n = 8192;
+        let tone_bin = (10_000.0_f32 / (sr / hf_n as f32)).round() as usize;
+        let hf = make_spectrum(hf_n, tone_bin, 0.0, -180.0);
+        let lf = make_spectrum(65536, 4, -60.0, -180.0); // quiet LF content
+
+        let n_cols = 500;
+        let cols = spectrum_to_columns_multiband(&lf, &hf, sr, 750.0, 20.0, 20000.0, n_cols);
+        let decade = (20000.0_f32 / 20.0).log10();
+        let col_freq = |i: usize| 20.0_f32 * 10f32.powf(decade * (i as f32 + 0.5) / n_cols as f32);
+
+        let peak = cols.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        assert!(peak >= -1.0, "HF peak {peak} did not survive merge");
+        for (i, &v) in cols.iter().enumerate() {
+            let f = col_freq(i);
+            if (f - 10_000.0).abs() > 2_000.0 && f > 750.0 {
+                assert!(
+                    v <= -150.0,
+                    "column {i} at {f:.0} Hz leaked HF energy: {v} dB"
+                );
+            }
+        }
+    }
+
+    /// A flat input through both bands stays flat across the crossover —
+    /// no splice step or doubled peak in the blend region (#142 risk).
+    #[test]
+    fn multiband_crossover_is_continuous() {
+        let lf = vec![-40.0_f32; 65536 / 2 + 1];
+        let hf = vec![-40.0_f32; 8192 / 2 + 1];
+        let cols = spectrum_to_columns_multiband(&lf, &hf, 48_000.0, 750.0, 20.0, 20000.0, 1024);
+        for (i, w) in cols.windows(2).enumerate() {
+            assert!(
+                (w[0] - w[1]).abs() < 0.5,
+                "discontinuity at column {i}: {} -> {}",
+                w[0],
+                w[1],
+            );
+        }
+    }
+
+    /// Empty LF spectrum (ring not yet full) degrades to pure HF columns.
+    #[test]
+    fn multiband_empty_lf_falls_back_to_hf() {
+        let hf = make_spectrum(8192, 100, 0.0, -180.0);
+        let merged = spectrum_to_columns_multiband(&[], &hf, 48_000.0, 750.0, 20.0, 20000.0, 256);
+        let hf_only = spectrum_to_columns(&hf, 48_000.0, 20.0, 20000.0, 256);
+        assert_eq!(merged, hf_only);
     }
 }

--- a/ac-rs/crates/ac-daemon/src/handlers/admin.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/admin.rs
@@ -386,7 +386,16 @@ pub fn set_monitor_params(state: &ServerState, cmd: &Value) -> Value {
     if let Some(n) = req_fft_n {
         mp.fft_n = n;
     }
-    json!({"ok": true, "interval": mp.interval, "fft_n": mp.fft_n})
+    // `lf_fft_n` / `crossover_hz` are daemon-owned constants the UI can't set
+    // in this issue — echo them read-only so the LF resolution label stays
+    // single-sourced from the daemon (#142).
+    json!({
+        "ok": true,
+        "interval": mp.interval,
+        "fft_n": mp.fft_n,
+        "lf_fft_n": mp.lf_fft_n,
+        "crossover_hz": mp.crossover_hz,
+    })
 }
 
 pub fn server_connections(state: &ServerState) -> Value {

--- a/ac-rs/crates/ac-daemon/src/handlers/audio/monitor.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/audio/monitor.rs
@@ -276,11 +276,15 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
         return json!({"ok": false, "error": "fft_n must be power of 2 in [256, 131072]"});
     }
 
+    let lf_fft_n = defaults.lf_fft_n;
+    let crossover_hz = defaults.crossover_hz;
     {
         let mut mp = state.monitor_params.lock().unwrap();
         *mp = MonitorParams {
             interval,
             fft_n,
+            lf_fft_n,
+            crossover_hz,
             active: true,
         };
     }
@@ -477,6 +481,21 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
             .map(|_| std::collections::VecDeque::with_capacity(131_072))
             .collect();
 
+        // Dual-resolution low-frequency path (#142). A second, longer ring
+        // feeds an `lf_fft_n`-point FFT used only below `crossover_hz`; the
+        // short `fft_rings` above keep driving the high band at the live
+        // refresh rate. The LF spectrum is recomputed at most once per LF
+        // block duration (`lf_fft_n / sr`) — LF content is slow-moving, so
+        // this caps the extra CPU instead of paying a long FFT every tick.
+        // `lf_spec_cache` holds the most recent LF linear half-spectrum per
+        // channel (`None` until its ring first fills).
+        let mut lf_fft_rings: Vec<std::collections::VecDeque<f32>> = channels_worker
+            .iter()
+            .map(|_| std::collections::VecDeque::with_capacity(131_072))
+            .collect();
+        let mut lf_spec_cache: Vec<Option<Vec<f64>>> = vec![None; channels_worker.len()];
+        let mut lf_ticks_since_recompute: Vec<u32> = vec![u32::MAX; channels_worker.len()];
+
         // Per-channel time-integration state for the `fractional_octave_leq`
         // sidecar frame. `None` until the first fractional_octave frame at
         // the current mode + band count arrives. Reset on mode/band-count
@@ -510,10 +529,18 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_nanos() as u64)
                 .unwrap_or(0);
-            let (cur_interval, cur_fft_n) = {
+            let (cur_interval, cur_fft_n, cur_lf_fft_n, cur_crossover_hz) = {
                 let mp = monitor_params_shared.lock().unwrap();
-                (mp.interval, mp.fft_n)
+                (mp.interval, mp.fft_n, mp.lf_fft_n, mp.crossover_hz)
             };
+            // LF band is only worth running when its FFT is genuinely longer
+            // than the live one — otherwise the live spectrum already has
+            // equal-or-finer Δf everywhere.
+            let lf_band_enabled = cur_lf_fft_n > cur_fft_n;
+            // Recompute the LF FFT at most once per LF block duration.
+            let lf_recompute_every = ((cur_lf_fft_n as f64 / sr as f64) / cur_interval.max(1e-6))
+                .round()
+                .clamp(1.0, 4096.0) as u32;
             let mode = analysis_mode.lock().unwrap().clone();
             let is_cwt = mode == "cwt";
             let is_cqt = mode == "cqt";
@@ -1075,6 +1102,41 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                 }
                 let samples = ring.make_contiguous();
 
+                // Dual-resolution LF path (#142): keep a longer ring fed by the
+                // same capture and recompute its long-N spectrum on the LF
+                // cadence. The cached LF half-spectrum is merged below the
+                // crossover; above it the live `r.spectrum` is untouched.
+                if lf_band_enabled {
+                    let lf_ring = &mut lf_fft_rings[idx];
+                    lf_ring.extend(new.iter());
+                    while lf_ring.len() > cur_lf_fft_n as usize {
+                        lf_ring.pop_front();
+                    }
+                    if lf_ring.len() >= cur_lf_fft_n as usize {
+                        let counter = &mut lf_ticks_since_recompute[idx];
+                        if *counter >= lf_recompute_every {
+                            let lf_buf = lf_ring.make_contiguous();
+                            let (lf_spec, _) =
+                                ac_core::visualize::spectrum::spectrum_only(lf_buf, sr);
+                            lf_spec_cache[idx] = Some(lf_spec);
+                            *counter = 0;
+                        } else {
+                            *counter = counter.saturating_add(1);
+                        }
+                    }
+                } else if !lf_fft_rings[idx].is_empty() || lf_spec_cache[idx].is_some() {
+                    // LF band disabled (live N caught up to LF N) — drop stale
+                    // state so a later re-enable rebuilds from fresh capture.
+                    lf_fft_rings[idx].clear();
+                    lf_spec_cache[idx] = None;
+                    lf_ticks_since_recompute[idx] = u32::MAX;
+                }
+                let lf_spec_for_merge: Option<&[f64]> = if lf_band_enabled {
+                    lf_spec_cache[idx].as_deref()
+                } else {
+                    None
+                };
+
                 {
                     let analyze_result =
                         ac_core::measurement::thd::analyze(samples, sr, current_freqs[idx], 10);
@@ -1108,23 +1170,61 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                             let raw_freqs: Vec<f64> = (0..raw_n)
                                 .map(|k| k as f64 * sr as f64 / (2.0 * (raw_n - 1).max(1) as f64))
                                 .collect();
-                            let peaks = ac_core::visualize::spectrum::find_interpolated_peaks(
+                            let peak_thr = r.fundamental_dbfs as f32 - 80.0;
+                            let mut peaks = ac_core::visualize::spectrum::find_interpolated_peaks(
                                 &r.spectrum,
                                 &raw_freqs,
                                 64,
-                                r.fundamental_dbfs as f32 - 80.0,
+                                peak_thr,
                             );
+                            // Below the crossover the long-N LF spectrum gives
+                            // finer peak positions; splice LF peaks under the
+                            // crossover with HF peaks above it (#142).
+                            if let Some(lf) = lf_spec_for_merge {
+                                let cx = cur_crossover_hz;
+                                let lf_n = lf.len();
+                                let lf_freqs: Vec<f64> = (0..lf_n)
+                                    .map(|k| {
+                                        k as f64 * sr as f64 / (2.0 * (lf_n - 1).max(1) as f64)
+                                    })
+                                    .collect();
+                                let mut lf_peaks =
+                                    ac_core::visualize::spectrum::find_interpolated_peaks(
+                                        lf, &lf_freqs, 64, peak_thr,
+                                    );
+                                peaks.retain(|p| p.freq_hz >= cx);
+                                lf_peaks.retain(|p| p.freq_hz < cx);
+                                peaks.append(&mut lf_peaks);
+                                peaks.sort_by(|a, b| {
+                                    b.dbfs
+                                        .partial_cmp(&a.dbfs)
+                                        .unwrap_or(std::cmp::Ordering::Equal)
+                                });
+                                peaks.truncate(64);
+                            }
                             let peaks_json: Vec<serde_json::Value> =
                                 peaks.iter().map(|p| json!([p.freq_hz, p.dbfs])).collect();
                             let sr_f = sr as f64;
-                            let (mut spec, freqs) =
-                                ac_core::visualize::aggregate::spectrum_to_columns_wire(
+                            let (mut spec, freqs) = match lf_spec_for_merge {
+                                Some(lf) => {
+                                    ac_core::visualize::aggregate::spectrum_to_columns_multiband_wire(
+                                        lf,
+                                        &r.spectrum,
+                                        sr_f,
+                                        cur_crossover_hz as f64,
+                                        20.0,
+                                        (sr_f / 2.0).max(21.0),
+                                        ac_core::visualize::aggregate::DEFAULT_WIRE_COLUMNS,
+                                    )
+                                }
+                                None => ac_core::visualize::aggregate::spectrum_to_columns_wire(
                                     &r.spectrum,
                                     sr_f,
                                     20.0,
                                     (sr_f / 2.0).max(21.0),
                                     ac_core::visualize::aggregate::DEFAULT_WIRE_COLUMNS,
-                                );
+                                ),
+                            };
                             if mc_enabled {
                                 if let Some(curve) = &mic_curves[idx] {
                                     apply_mic_curve_inplace_f64(curve, &freqs, &mut spec);
@@ -1162,14 +1262,26 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                             let (spec, _) =
                                 ac_core::visualize::spectrum::spectrum_only(samples, sr);
                             let sr_f = sr as f64;
-                            let (mut spec, freqs) =
-                                ac_core::visualize::aggregate::spectrum_to_columns_wire(
+                            let (mut spec, freqs) = match lf_spec_for_merge {
+                                Some(lf) => {
+                                    ac_core::visualize::aggregate::spectrum_to_columns_multiband_wire(
+                                        lf,
+                                        &spec,
+                                        sr_f,
+                                        cur_crossover_hz as f64,
+                                        20.0,
+                                        (sr_f / 2.0).max(21.0),
+                                        ac_core::visualize::aggregate::DEFAULT_WIRE_COLUMNS,
+                                    )
+                                }
+                                None => ac_core::visualize::aggregate::spectrum_to_columns_wire(
                                     &spec,
                                     sr_f,
                                     20.0,
                                     (sr_f / 2.0).max(21.0),
                                     ac_core::visualize::aggregate::DEFAULT_WIRE_COLUMNS,
-                                );
+                                ),
+                            };
                             if mc_enabled {
                                 if let Some(curve) = &mic_curves[idx] {
                                     apply_mic_curve_inplace_f64(curve, &freqs, &mut spec);
@@ -1232,9 +1344,11 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
     }
     json!({
         "ok": true,
-        "in_port":   primary_in_port,
-        "in_ports":  in_ports,
-        "channels":  channels,
+        "in_port":      primary_in_port,
+        "in_ports":     in_ports,
+        "channels":     channels,
+        "lf_fft_n":     lf_fft_n,
+        "crossover_hz": crossover_hz,
     })
 }
 

--- a/ac-rs/crates/ac-daemon/src/server.rs
+++ b/ac-rs/crates/ac-daemon/src/server.rs
@@ -105,6 +105,14 @@ pub struct MonitorParams {
     pub interval: f64,
     /// FFT window length in samples. Must be a power of 2 in [256, 131072].
     pub fft_n: u32,
+    /// Low-frequency FFT window length for the dual-resolution path (#142).
+    /// A second, longer FFT over the same ring drives the spectrum below
+    /// `crossover_hz`; the live `fft_n` keeps driving everything above it.
+    /// The LF band is inactive whenever `fft_n >= lf_fft_n`.
+    pub lf_fft_n: u32,
+    /// Crossover (Hz) splitting the LF long-FFT band from the HF live band.
+    /// Daemon-owned constant, echoed to the UI so labels never hardcode it.
+    pub crossover_hz: f32,
     /// `monitor_spectrum` worker is running.
     pub active: bool,
 }
@@ -113,9 +121,13 @@ impl Default for MonitorParams {
     fn default() -> Self {
         // 8192 @ 48 kHz ≈ 5.86 Hz bin spacing — close to legacy 0.2 s × 48 k
         // = 9600 samples (≈ 5 Hz) while being a clean pow2 for the planner.
+        // LF N=65536 @ 48 kHz ≈ 0.73 Hz, enough to split 5 Hz tones < 100 Hz
+        // (block latency ≈ 1.37 s, applied to the LF band only — #142).
         Self {
             interval: 0.2,
             fft_n: 8192,
+            lf_fft_n: 65536,
+            crossover_hz: ac_core::visualize::aggregate::DEFAULT_LF_CROSSOVER_HZ,
             active: false,
         }
     }

--- a/ac-rs/crates/ac-ui/src/app.rs
+++ b/ac-rs/crates/ac-ui/src/app.rs
@@ -252,6 +252,12 @@ pub struct App {
     /// and pushed to the daemon via `set_monitor_params`.
     monitor_interval_ms: u32,
     monitor_fft_n: u32,
+    /// Dual-resolution LF band params learned from the daemon's
+    /// `monitor_spectrum` reply (#142). Daemon-owned constants — the UI never
+    /// hardcodes them, only labels with them. `None` until the first reply.
+    /// The LF band is active only while `monitor_fft_n < monitor_lf_fft_n`.
+    monitor_lf_fft_n: Option<u32>,
+    monitor_crossover_hz: Option<f32>,
     /// Insertion-order view of `selected`. Compare layout renders cells in
     /// selection order; the T key reads the first and last entries to form
     /// a virtual transfer pair (meas = first, ref = last).
@@ -597,6 +603,8 @@ impl App {
             // assuming 48 kHz so the very first tick doesn't overshoot.
             monitor_interval_ms: auto_monitor_interval_ms(8192, 48_000),
             monitor_fft_n: 8192,
+            monitor_lf_fft_n: None,
+            monitor_crossover_hz: None,
             selection_order: Vec::new(),
             config,
             cell_views: Vec::new(),

--- a/ac-rs/crates/ac-ui/src/app/control.rs
+++ b/ac-rs/crates/ac-ui/src/app/control.rs
@@ -416,6 +416,17 @@ impl App {
                 log::info!("monitor_spectrum reply: {reply}");
                 if reply.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
                     self.monitor_spectrum_active = true;
+                    // Learn the daemon's dual-resolution LF constants so the
+                    // readout can label the LF band without hardcoding them
+                    // (#142). Absent fields → LF feature off on this daemon.
+                    self.monitor_lf_fft_n = reply
+                        .get("lf_fft_n")
+                        .and_then(|v| v.as_u64())
+                        .map(|v| v as u32);
+                    self.monitor_crossover_hz = reply
+                        .get("crossover_hz")
+                        .and_then(|v| v.as_f64())
+                        .map(|v| v as f32);
                 } else {
                     let err = reply.get("error").and_then(|v| v.as_str()).unwrap_or("?");
                     self.notify(&format!("monitor_spectrum: {err}"));

--- a/ac-rs/crates/ac-ui/src/app/render_pipeline.rs
+++ b/ac-rs/crates/ac-ui/src/app/render_pipeline.rs
@@ -834,9 +834,18 @@ impl App {
             .collect();
         let n_real_snap = n_real;
         let show_help_snap = self.show_help;
+        // LF band is active only while the live N is below the daemon's LF N;
+        // once the user raises N to/above it the live spectrum is already at
+        // least as fine, so the LF augmentation (and its readout line) drops
+        // back to the single-line fallback (#142).
+        let lf_active = self
+            .monitor_lf_fft_n
+            .filter(|&lf_n| lf_n > self.monitor_fft_n);
         let monitor_params_snap = (self.analysis_mode == "fft").then_some(MonitorParamsInfo {
             interval_ms: self.monitor_interval_ms,
             fft_n: self.monitor_fft_n,
+            lf_fft_n: lf_active,
+            crossover_hz: lf_active.and(self.monitor_crossover_hz),
         });
         // For the CQT badge we need the live `f_min` — the daemon
         // clamps it dynamically above the const default based on ring

--- a/ac-rs/crates/ac-ui/src/ui/fmt.rs
+++ b/ac-rs/crates/ac-ui/src/ui/fmt.rs
@@ -119,9 +119,46 @@ pub fn spectrum_readout(
 /// Live-monitor readout for the FFT knobs shown top-right in Spectrum mode.
 /// Pure function so the exact text — including the `Δf = sr / N` math — is
 /// covered by unit tests rather than only by the paint-test harness.
-pub fn monitor_knobs_readout(interval_ms: u32, fft_n: u32, sr: u32) -> String {
+///
+/// When `lf_fft_n` / `crossover_hz` are `Some` the dual-resolution LF path
+/// is active (#142) and a second line is appended (`\n`-separated): the
+/// HF (interactive) line gains a `≥ {crossover} Hz` scope tag and the LF
+/// line reports the long-FFT `N`, its finer `Δf`, and the LF block latency.
+/// When `None` the output is byte-for-byte today's single line — the
+/// fallback for daemons without the feature or when live N ≥ LF N.
+pub fn monitor_knobs_readout(
+    interval_ms: u32,
+    fft_n: u32,
+    sr: u32,
+    lf_fft_n: Option<u32>,
+    crossover_hz: Option<f32>,
+) -> String {
     let df = sr as f32 / fft_n.max(1) as f32;
-    format!("{:>4} ms  │  N {}  │  Δf {:.1} Hz", interval_ms, fft_n, df)
+    let hf = format!("{:>4} ms  │  N {}  │  Δf {:.1} Hz", interval_ms, fft_n, df);
+
+    match (lf_fft_n, crossover_hz) {
+        (Some(lf_n), Some(cx)) => {
+            let lf_df = sr as f32 / lf_n.max(1) as f32;
+            // LF block latency = N / sr — the inherent slow-update trade-off.
+            let lf_latency_s = lf_n as f32 / sr.max(1) as f32;
+            format!(
+                "{hf}   ≥ {cx:.0} Hz\nLF     │  N {lf_n}  │  Δf {} Hz  < {cx:.0} Hz · {lf_latency_s:.1} s",
+                fmt_delta_f(lf_df),
+            )
+        }
+        _ => hf,
+    }
+}
+
+/// Adaptive-precision Δf formatter for the LF band: sub-10 Hz spacings get
+/// 2 decimals so the sub-Hz LF resolution (e.g. `0.73`) isn't rounded away;
+/// ≥ 10 Hz keeps 1 decimal.
+fn fmt_delta_f(df_hz: f32) -> String {
+    if df_hz < 10.0 {
+        format!("{df_hz:.2}")
+    } else {
+        format!("{df_hz:.1}")
+    }
 }
 
 /// Compact label for the top-right top-line ("{sr} Hz │ {channel}").
@@ -838,19 +875,19 @@ mod tests {
     #[test]
     fn monitor_knobs_delta_f_math() {
         // Δf = sr / N. 48000 / 4096 = 11.71875 → rounds to "11.7 Hz".
-        let s = monitor_knobs_readout(10, 4096, 48_000);
+        let s = monitor_knobs_readout(10, 4096, 48_000, None, None);
         assert!(s.contains("Δf 11.7 Hz"), "got: {s}");
         // 96 kHz, N = 8192 → 11.71875 as well.
-        let s = monitor_knobs_readout(10, 8192, 96_000);
+        let s = monitor_knobs_readout(10, 8192, 96_000, None, None);
         assert!(s.contains("Δf 11.7 Hz"), "got: {s}");
         // 48 kHz, N = 2048 → 23.4375 → "23.4 Hz".
-        let s = monitor_knobs_readout(5, 2048, 48_000);
+        let s = monitor_knobs_readout(5, 2048, 48_000, None, None);
         assert!(s.contains("Δf 23.4 Hz"), "got: {s}");
     }
 
     #[test]
     fn monitor_knobs_formats_interval_and_n() {
-        let s = monitor_knobs_readout(7, 16384, 48_000);
+        let s = monitor_knobs_readout(7, 16384, 48_000, None, None);
         assert!(s.contains("   7 ms"));
         assert!(s.contains("N 16384"));
     }
@@ -858,7 +895,43 @@ mod tests {
     #[test]
     fn monitor_knobs_zero_n_does_not_panic() {
         // Defensive guard — mp.fft_n.max(1).
-        let _ = monitor_knobs_readout(1, 0, 48_000);
+        let _ = monitor_knobs_readout(1, 0, 48_000, None, None);
+        let _ = monitor_knobs_readout(1, 8192, 48_000, Some(0), Some(750.0));
+    }
+
+    #[test]
+    fn monitor_knobs_single_line_fallback_is_unchanged() {
+        // `None` LF params → today's exact one-line output, no LF line,
+        // no `≥` scope tag (#142 fallback).
+        let s = monitor_knobs_readout(10, 16384, 48_000, None, None);
+        assert_eq!(s, "  10 ms  │  N 16384  │  Δf 2.9 Hz");
+        assert!(!s.contains('\n'));
+        assert!(!s.contains("LF"));
+        assert!(!s.contains('≥'));
+    }
+
+    #[test]
+    fn monitor_knobs_two_line_when_lf_active() {
+        // HF N=16384 @ 48k → Δf 2.9 Hz; LF N=65536 → Δf 0.73 Hz, latency 1.4 s.
+        let s = monitor_knobs_readout(10, 16384, 48_000, Some(65536), Some(750.0));
+        let lines: Vec<&str> = s.lines().collect();
+        assert_eq!(lines.len(), 2, "expected two lines, got: {s:?}");
+        // HF line keeps its byte-for-byte knobs and gains the scope tag.
+        assert!(lines[0].starts_with("  10 ms  │  N 16384  │  Δf 2.9 Hz"));
+        assert!(lines[0].contains("≥ 750 Hz"));
+        // LF line: long N, sub-Hz Δf at 2 decimals, crossover + latency.
+        assert!(lines[1].contains("N 65536"));
+        assert!(lines[1].contains("Δf 0.73 Hz"), "got: {}", lines[1]);
+        assert!(lines[1].contains("< 750 Hz"));
+        assert!(lines[1].contains("· 1.4 s"));
+    }
+
+    #[test]
+    fn monitor_knobs_lf_delta_f_adaptive_decimals() {
+        // LF Δf ≥ 10 Hz uses 1 decimal (e.g. tiny LF N); < 10 Hz uses 2.
+        let s = monitor_knobs_readout(10, 1024, 48_000, Some(2048), Some(750.0));
+        // 48000/2048 = 23.4375 → "23.4" (1 decimal).
+        assert!(s.contains("Δf 23.4 Hz"), "got: {s}");
     }
 
     // ── top-right status ──────────────────────────────────────────────

--- a/ac-rs/crates/ac-ui/src/ui/overlay.rs
+++ b/ac-rs/crates/ac-ui/src/ui/overlay.rs
@@ -219,6 +219,11 @@ pub(crate) fn channel_label(idx: usize, n_real: usize, virtual_pairs: &[Transfer
 pub struct MonitorParamsInfo {
     pub interval_ms: u32,
     pub fft_n: u32,
+    /// Dual-resolution LF band (#142). `Some` only when the LF path is
+    /// active (live N below the daemon's LF N); drives the second readout
+    /// line. `None` → single-line fallback (today's exact output).
+    pub lf_fft_n: Option<u32>,
+    pub crossover_hz: Option<f32>,
 }
 
 // Help overlay — RC-9 trim, ≤30 lines, organized by view family. The
@@ -432,18 +437,27 @@ pub fn draw(ctx: &Context, input: OverlayInput<'_>) {
         let mut stack_row: f32 = 2.0;
         if matches!(input.config.view_mode, ViewMode::Spectrum) {
             if let Some(mp) = input.monitor_params {
-                let mon_line = super::fmt::monitor_knobs_readout(mp.interval_ms, mp.fft_n, sr);
-                painter.text(
-                    Pos2::new(
-                        screen.right() - 8.0,
-                        screen.top() + 6.0 + stack_row * (theme::STATUS_PX + 2.0),
-                    ),
-                    Align2::RIGHT_TOP,
-                    mon_line,
-                    FontId::monospace(theme::STATUS_PX),
-                    text_color,
+                // One or two lines (#142): line 2 is the LF band when active.
+                let mon_text = super::fmt::monitor_knobs_readout(
+                    mp.interval_ms,
+                    mp.fft_n,
+                    sr,
+                    mp.lf_fft_n,
+                    mp.crossover_hz,
                 );
-                stack_row += 1.0;
+                for mon_line in mon_text.lines() {
+                    painter.text(
+                        Pos2::new(
+                            screen.right() - 8.0,
+                            screen.top() + 6.0 + stack_row * (theme::STATUS_PX + 2.0),
+                        ),
+                        Align2::RIGHT_TOP,
+                        mon_line,
+                        FontId::monospace(theme::STATUS_PX),
+                        text_color,
+                    );
+                    stack_row += 1.0;
+                }
             }
         }
         if let Some(badge) = input.tier_badge.as_deref() {


### PR DESCRIPTION
closes #142

### what changed
Adds a dual-resolution low-frequency path to the FFT spectrum monitor (architect option B). The daemon runs a second, longer FFT (`lf_fft_n`, default 65536 ≈ 0.73 Hz Δf @ 48 kHz) over the *same* capture ring and uses it only below a fixed crossover (`crossover_hz`, default 750 Hz); the live short-N FFT keeps driving everything above the crossover at the normal refresh rate. The two linear half-spectra are merged into the **unchanged** log-column `spectrum` wire frame by a new additive `ac-core` function, cross-faded linearly in dB across a ±1/6-octave band so the splice is seamless. `lf_fft_n`/`crossover_hz` are daemon-owned constants echoed over the control channel (not the data frame) so the UI labels the two bands honestly without hardcoding daemon values.

### files touched
- `ac-core/src/visualize/aggregate.rs` — new `spectrum_to_columns_multiband` + `_wire` (additive; existing signatures unchanged), `DEFAULT_LF_CROSSOVER_HZ` const, shared `column_centre_freqs` helper, + 4 tests.
- `ac-daemon/src/server.rs` — `MonitorParams` gains `lf_fft_n` / `crossover_hz` (defaulted).
- `ac-daemon/src/handlers/audio/monitor.rs` — per-channel LF ring + long-N FFT recomputed at most once per LF block (~1.4 s) to bound CPU; merge below crossover; LF-spectrum peak detection below crossover, HF above; LF constants in the start reply.
- `ac-daemon/src/handlers/admin.rs` — `set_monitor_params` echoes `lf_fft_n`/`crossover_hz` read-only.
- `ac-ui/src/app.rs`, `app/control.rs` — learn LF constants from the monitor-start reply (no UI-side hardcoding).
- `ac-ui/src/app/render_pipeline.rs` — LF band active only while live N < LF N (else single-line fallback).
- `ac-ui/src/ui/overlay.rs` — paints the 1- or 2-line readout.
- `ac-ui/src/ui/fmt.rs` — `monitor_knobs_readout` two-line output: HF line scoped `≥ {crossover} Hz`, LF line with adaptive sub-Hz Δf precision + LF block latency; single-line output unchanged when LF inactive; + 4 tests.
- `ZMQ.md` — documents the path, the resolution/latency trade-off, and the new reply fields (acceptance criterion #4).

### test output
```
ac-core:  271 passed; 0 failed
ac-cli:   82 + 47 passed; 0 failed
ac-daemon: 63 + 4 passed; 0 failed (1 ignored — JACK runbook)
ac-ui:    224 passed; 0 failed
cargo clippy --all-targets -- -D warnings: clean
cargo fmt --check: clean
```
New tests: `close_tones_resolve_multiband` (5 Hz tones < 100 Hz resolve — criterion #1), `multiband_preserves_hf_peak` (HF peak survives — criterion #2), `multiband_crossover_is_continuous` (no splice step), `multiband_empty_lf_falls_back_to_hf`; fmt: single-line fallback unchanged, two-line when LF active, adaptive Δf decimals.

### ac-daemon IPC schema changed
yes — **control channel only** (additive). `monitor_spectrum` and `set_monitor_params` replies gain read-only `lf_fft_n` + `crossover_hz`. The `spectrum`/`freqs` **data** frame is unchanged; existing subscribers need no changes.

### new dependencies
none

### related
none

### open questions for reviewer
- **Deviation from the 3-field design:** the architect's addendum listed `lf_interval` as a third surfaced field. I derive the LF latency (`lf_fft_n / sr`) in the UI instead — identical pattern to the existing HF `Δf = sr / fft_n` derivation, so no redundant daemon state and no drift risk. The UX "· 1.4 s" label is exactly `lf_fft_n / sr`. Flag if you'd prefer the explicit field.
- **LF recompute cadence** is `round((lf_fft_n/sr) / interval)` ticks (≈ once per LF block). The displayed latency is the LF *block length*, which is the honest inherent latency regardless of recompute cadence. Reasonable?
- **Crossover** is a fixed daemon constant (750 Hz) per the architect's decision; no keybinding. Confirm that's the intended scope for this issue.
- DSP verification is `--fake-audio`/test-vector only here; a hardware-in-the-loop check on the FF400 rig (two real LF tones 5 Hz apart) would be good QA confirmation of criterion #1 end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
