### PR TITLE
feat: hz/amplitude cursor readout in ember spectrum (#154)

### DIFF
--- a/ac-rs/crates/ac-ui/src/app/render_pipeline.rs
+++ b/ac-rs/crates/ac-ui/src/app/render_pipeline.rs
@@ -925,6 +925,11 @@ impl App {
                 let rows_back = (1.0 - ny) * (rows_visible - 1.0).max(0.0);
                 let t_ago = rows_back * self.waterfall_row_period_s;
                 HoverReadout::TimeAgo(t_ago)
+            } else if matches!(config_snap.view_mode, ViewMode::SpectrumEmber) {
+                // Ember footer reads the trace magnitude at the hovered bin
+                // (sampled from the frame spectrum in the overlay), not the
+                // geometric cursor-Y. The dB is filled in there (#154).
+                HoverReadout::SpectrumBin
             } else {
                 let db = view.db_min + ny * (view.db_max - view.db_min);
                 HoverReadout::Db(db)

--- a/ac-rs/crates/ac-ui/src/ui/fmt.rs
+++ b/ac-rs/crates/ac-ui/src/ui/fmt.rs
@@ -253,6 +253,24 @@ pub fn sweep_readout(pt: &SweepPoint) -> String {
     parts.join("   ")
 }
 
+/// Nearest detected peak within the snap window: 1% of the cursor
+/// frequency, floored at 2 Hz so low-freq peaks (where 1% is sub-Hz)
+/// still snap reliably. Returns the snapped peak's `(freq_hz, db)`, or
+/// `None` when no peak is close enough.
+fn snap_to_peak(cursor_freq_hz: f32, peaks: &[[f32; 2]]) -> Option<(f32, f32)> {
+    let snap_tol_hz = (cursor_freq_hz * 0.01).max(2.0);
+    let mut best: Option<(f32, f32)> = None;
+    let mut best_dist = f32::INFINITY;
+    for p in peaks {
+        let d = (p[0] - cursor_freq_hz).abs();
+        if d < best_dist && d <= snap_tol_hz {
+            best_dist = d;
+            best = Some((p[0], p[1]));
+        }
+    }
+    best
+}
+
 /// Cursor-driven footer readout for the spectrum / waterfall / sweep
 /// views. Replaces the broadband stats line whenever the cursor is
 /// over a cell — keeps the trace unobstructed and gives the dBu /
@@ -277,6 +295,9 @@ pub fn sweep_readout(pt: &SweepPoint) -> String {
 ///   plus dBu / dB SPL via the same cal offsets the spectrum view uses.
 /// - `Thd(v)` / `Gain(v)`: Sweep cursor panels. Show their value with
 ///   the cursor freq.
+/// - `SpectrumBin`: SpectrumEmber cursor. Amplitude is the *trace* bin
+///   magnitude from `sampled_db_at_freq` (not a geometric cursor-Y);
+///   snaps to a known peak like `Db`, and an empty sample renders `—`.
 pub fn cursor_readout(
     cursor_freq_hz: f32,
     readout: &crate::ui::overlay::HoverReadout,
@@ -288,19 +309,7 @@ pub fn cursor_readout(
     use crate::ui::overlay::HoverReadout;
     match *readout {
         HoverReadout::Db(cursor_db_at_bin) => {
-            // Snap window: 1% of cursor freq, floor at 2 Hz so low-freq
-            // peaks (where 1% is sub-Hz) still snap reliably.
-            let snap_tol_hz = (cursor_freq_hz * 0.01).max(2.0);
-            let mut best: Option<(f32, f32)> = None;
-            let mut best_dist = f32::INFINITY;
-            for p in peaks {
-                let d = (p[0] - cursor_freq_hz).abs();
-                if d < best_dist && d <= snap_tol_hz {
-                    best_dist = d;
-                    best = Some((p[0], p[1]));
-                }
-            }
-            let (freq, db, snapped) = match best {
+            let (freq, db, snapped) = match snap_to_peak(cursor_freq_hz, peaks) {
                 Some((f, d)) => (f, d, true),
                 None => (cursor_freq_hz, cursor_db_at_bin, false),
             };
@@ -319,6 +328,35 @@ pub fn cursor_readout(
                 )
             } else {
                 format!("{} {:+6.2} dBFS{}", format_hz(freq), db, snap_tag,)
+            }
+        }
+        HoverReadout::SpectrumBin => {
+            // Amplitude is the trace magnitude at the hovered bin
+            // (`sampled_db_at_freq`), or the snapped peak's dB when the
+            // cursor is inside the snap window. No sample (empty spectrum or
+            // cursor past the trace edge) → `—`, never a fabricated 0 dB.
+            let (freq, db, snapped) = match snap_to_peak(cursor_freq_hz, peaks) {
+                Some((f, d)) => (f, Some(d), true),
+                None => (cursor_freq_hz, sampled_db_at_freq, false),
+            };
+            let snap_tag = if snapped { "  ▲" } else { "" };
+            match db {
+                None => format!("{} {:>6} dBFS", format_hz(freq), "—"),
+                Some(db) => {
+                    if let Some(off) = spl_offset_db {
+                        format!("{} {:>6.1} dB SPL{}", format_hz(freq), db + off, snap_tag,)
+                    } else if let Some(off) = dbu_offset_db {
+                        format!(
+                            "{} {:+6.2} dBFS  {:+6.2} dBu{}",
+                            format_hz(freq),
+                            db,
+                            db + off,
+                            snap_tag,
+                        )
+                    } else {
+                        format!("{} {:+6.2} dBFS{}", format_hz(freq), db, snap_tag,)
+                    }
+                }
             }
         }
         HoverReadout::TimeAgo(s) => {
@@ -798,6 +836,102 @@ mod tests {
             !s.contains("dBu"),
             "should not show dBu when SPL active: {s}"
         );
+    }
+
+    #[test]
+    fn cursor_readout_spectrum_bin_uses_sampled_magnitude() {
+        // #154: ember cursor amplitude is the sampled trace bin magnitude,
+        // NOT the geometric cursor-Y. The Db payload is irrelevant here.
+        let s = cursor_readout(
+            2000.0,
+            &HoverReadout::SpectrumBin,
+            Some(-78.34),
+            &[],
+            None,
+            None,
+        );
+        assert!(s.contains("kHz"), "want freq unit: {s}");
+        assert!(s.contains("-78.34 dBFS"), "want sampled bin dBFS: {s}");
+        assert!(!s.contains("▲"), "no peaks supplied -> no snap marker: {s}");
+    }
+
+    #[test]
+    fn cursor_readout_spectrum_bin_empty_sample_shows_dash() {
+        // Cursor past the trace edge / spectrum empty: report freq with a
+        // `—` amplitude, never a stale or fabricated 0 dB.
+        let s = cursor_readout(22050.0, &HoverReadout::SpectrumBin, None, &[], None, None);
+        assert!(s.contains("—"), "empty sample must show em-dash: {s}");
+        assert!(s.contains("dBFS"), "still labels the dBFS field: {s}");
+        assert!(!s.contains("0.00"), "must not fabricate 0 dB: {s}");
+    }
+
+    #[test]
+    fn cursor_readout_spectrum_bin_snaps_to_peak() {
+        // Within the 1% snap window the readout reports the peak's freq/dB
+        // (overriding the sampled value) and flags it with ▲.
+        let peaks = [[1000.0_f32, -0.02]];
+        let s = cursor_readout(
+            1001.0,
+            &HoverReadout::SpectrumBin,
+            Some(-40.0),
+            &peaks,
+            None,
+            None,
+        );
+        assert!(s.contains("-0.02 dBFS"), "want snapped peak dB: {s}");
+        assert!(s.contains("▲"), "want snap marker: {s}");
+        assert!(
+            !s.contains("-40.0"),
+            "snapped readout must drop the sample: {s}"
+        );
+    }
+
+    #[test]
+    fn cursor_readout_spectrum_bin_voltage_cal_adds_dbu() {
+        let s = cursor_readout(
+            1000.0,
+            &HoverReadout::SpectrumBin,
+            Some(-10.0),
+            &[],
+            Some(10.17),
+            None,
+        );
+        assert!(s.contains("-10.00 dBFS"), "want dBFS: {s}");
+        assert!(
+            s.contains("+0.17 dBu") || s.contains("+0.16 dBu") || s.contains("+0.18 dBu"),
+            "want dBu near +0.17: {s}"
+        );
+    }
+
+    #[test]
+    fn cursor_readout_spectrum_bin_spl_overrides_dbu() {
+        let s = cursor_readout(
+            1000.0,
+            &HoverReadout::SpectrumBin,
+            Some(-32.0),
+            &[],
+            Some(10.17),
+            Some(126.0),
+        );
+        assert!(s.contains("dB SPL"), "want SPL: {s}");
+        assert!(!s.contains("dBu"), "SPL overrides dBu: {s}");
+    }
+
+    #[test]
+    fn cursor_readout_spectrum_bin_empty_sample_ignores_cal() {
+        // No magnitude to convert -> show only the `—` dBFS field, no
+        // dangling dBu/SPL derived from nothing.
+        let s = cursor_readout(
+            1000.0,
+            &HoverReadout::SpectrumBin,
+            None,
+            &[],
+            Some(10.17),
+            Some(126.0),
+        );
+        assert!(s.contains("—"), "want em-dash: {s}");
+        assert!(!s.contains("dBu"), "no dBu without a sample: {s}");
+        assert!(!s.contains("SPL"), "no SPL without a sample: {s}");
     }
 
     #[test]

--- a/ac-rs/crates/ac-ui/src/ui/overlay.rs
+++ b/ac-rs/crates/ac-ui/src/ui/overlay.rs
@@ -30,6 +30,11 @@ pub enum HoverReadout {
     /// Waterfall/CWT cursor Y-axis is time, not dB. Payload is seconds-ago
     /// (0 at the top, newest row; grows downward toward older rows).
     TimeAgo(f32),
+    /// SpectrumEmber cursor: the amplitude is the *trace* magnitude at the
+    /// hovered FFT bin, sampled from the frame spectrum in the footer path —
+    /// not the geometric cursor-Y. Carries no payload; `cursor_readout`
+    /// sources the dB from `sampled_db_at_freq` (`None` sample → `—`).
+    SpectrumBin,
 }
 
 /// Colour hint for a single line of the loudness overlay — lets the R128
@@ -538,12 +543,10 @@ pub fn draw(ctx: &Context, input: OverlayInput<'_>) {
         // channel. No broadband fallback — toggling between cursor and
         // broadband stats every time the mouse crosses the cell edge
         // was confusing, and the broadband peak/floor/span info doesn't
-        // describe the cursor's position anyway. Suppressed in Scope /
-        // SpectrumEmber where the substrate owns the cell.
-        if !matches!(
-            input.config.view_mode,
-            ViewMode::Scope | ViewMode::SpectrumEmber
-        ) {
+        // describe the cursor's position anyway. Suppressed in Scope where
+        // the substrate owns the cell; SpectrumEmber surfaces the trace
+        // bin-magnitude readout (#154) via the SpectrumBin readout.
+        if !matches!(input.config.view_mode, ViewMode::Scope) {
             if let Some(hover) = input.hover.as_ref().filter(|h| h.channel == display_ch) {
                 // For colormap views (Waterfall / CWT / CQT / reassigned)
                 // the cursor's Y is time and the magnitude isn't on any
@@ -687,13 +690,18 @@ pub fn draw(ctx: &Context, input: OverlayInput<'_>) {
             1.0,
             Color32::from_rgba_unmultiplied(255, 255, 255, (0.55 * 255.0) as u8),
         );
-        painter.line_segment(
-            [
-                Pos2::new(hover.rect.left(), hover.cursor.y),
-                Pos2::new(hover.rect.right(), hover.cursor.y),
-            ],
-            crosshair,
-        );
+        // SpectrumEmber reports the trace bin magnitude in the footer, not a
+        // geometric cursor-Y dB (#154). A horizontal rule would imply a
+        // height-as-amplitude reading, so draw the vertical line only there.
+        if !matches!(input.config.view_mode, ViewMode::SpectrumEmber) {
+            painter.line_segment(
+                [
+                    Pos2::new(hover.rect.left(), hover.cursor.y),
+                    Pos2::new(hover.rect.right(), hover.cursor.y),
+                ],
+                crosshair,
+            );
+        }
         painter.line_segment(
             [
                 Pos2::new(hover.cursor.x, hover.rect.top()),

--- a/ac-rs/crates/ac-ui/src/ui/paint_tests.rs
+++ b/ac-rs/crates/ac-ui/src/ui/paint_tests.rs
@@ -794,7 +794,10 @@ fn overlay_ember_shows_gain_window_and_hold_tags() {
         ember.contains("Y -90..0 dB"),
         "gain window not shown: {ember:?}"
     );
-    assert!(!ember.contains("peak"), "peak tag must be absent: {ember:?}");
+    assert!(
+        !ember.contains("peak"),
+        "peak tag must be absent: {ember:?}"
+    );
     assert!(!ember.contains("min"), "min tag must be absent: {ember:?}");
 
     // Holds armed: both tags appear.
@@ -805,6 +808,69 @@ fn overlay_ember_shows_gain_window_and_hold_tags() {
         .unwrap_or_else(|| panic!("ember status line not found in: {texts:?}"));
     assert!(ember.contains("peak"), "peak tag missing: {ember:?}");
     assert!(ember.contains("min"), "min tag missing: {ember:?}");
+}
+
+#[test]
+fn overlay_ember_shows_cursor_readout_on_hover() {
+    // #154: the SpectrumEmber footer is no longer suppressed. Hovering
+    // surfaces freq + the trace bin magnitude sampled from the frame
+    // spectrum — NOT the geometric cursor-Y carried by the old Db payload.
+    let mut config = default_config();
+    config.view_mode = ViewMode::SpectrumEmber;
+    // Bright bin = -3 dBFS at ~1 kHz; the rest of the spectrum sits at -100.
+    let frame = test_frame(1000.0, -3.0, 0.003, 0.005);
+    let frames = [Some(frame)];
+    let cell_views = [CellView {
+        db_min: -90.0,
+        db_max: 0.0,
+        ..CellView::default()
+    }];
+    // Geometric payload deliberately -12 dBFS to prove it is ignored.
+    let mut hover = hover_at(0, 1000.0, -12.0);
+    hover.readout = HoverReadout::SpectrumBin;
+
+    let input = OverlayInput {
+        config: &config,
+        frames: &frames,
+        cell_views: &cell_views,
+        selected: &[false],
+        connected: true,
+        notification: None,
+        timing: None,
+        gpu_supported: true,
+        hover: Some(hover),
+        show_help: false,
+        monitor_params: None,
+        n_real: 1,
+        virtual_pairs: &[],
+        active_palette: 0,
+        smoothing_frac: None,
+        ioct_bpo: None,
+        tier_badge: None,
+        time_integration: None,
+        band_weighting: None,
+        loudness: None,
+        gonio_state: crate::data::types::StereoStatus::NoAudio,
+        bode_pair: None,
+        keytips: &[],
+        peak_hold: false,
+        min_hold: false,
+    };
+
+    let texts = run_overlay(input);
+    let has_readout = texts
+        .iter()
+        .any(|t| t.contains("kHz") && t.contains("dBFS"));
+    assert!(has_readout, "ember cursor readout missing: {texts:?}");
+    assert!(
+        texts.iter().any(|t| t.contains("-3.0")),
+        "amplitude must be the sampled bin magnitude (-3 dBFS), not the \
+         geometric -12 payload: {texts:?}"
+    );
+    assert!(
+        !texts.iter().any(|t| t.contains("-12.0")),
+        "geometric cursor-Y dB must not appear: {texts:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
closes #154

> Part of epic #152. #152 bundles two independent items (#153 ember two-line bug, #154 cursor readout). Per one-PR-per-issue this PR implements **#154 only**. #153 is untouched (it needs a HEAD repro first per the architect note).

### what changed
Un-suppressed the bottom-left footer readout for `ViewMode::SpectrumEmber` so hovering reports the frequency and the **trace bin magnitude** at the cursor. The amplitude comes from the sampled spectrum bin (`sample_spectrum_db_at_freq`), not the geometric cursor-Y. A new private `HoverReadout::SpectrumBin` variant carries the ember case so the regular Spectrum view's `Db` arm keeps its existing geometric semantics — no behaviour change outside ember.

### files touched
- `crates/ac-ui/src/ui/overlay.rs` — added `HoverReadout::SpectrumBin`; relaxed footer suppression from `Scope | SpectrumEmber` to `Scope` only; ember hover crosshair now draws the vertical line only (no horizontal rule, which would imply a height-as-amplitude reading).
- `crates/ac-ui/src/app/render_pipeline.rs` — hover builder emits `SpectrumBin` for `SpectrumEmber` instead of the geometric `Db(db)`.
- `crates/ac-ui/src/ui/fmt.rs` — `cursor_readout` gains a `SpectrumBin` arm: amplitude from `sampled_db_at_freq`, peak-snap (`▲`) within 1% of a known peak, `dBu`/`dB SPL` when calibrated, and `—` when the sample is `None` (cursor past trace edge / empty spectrum). Extracted the shared peak-snap loop into a `snap_to_peak` helper (used by both `Db` and `SpectrumBin` arms; `Db` behaviour identical).
- `crates/ac-ui/src/ui/paint_tests.rs` — integration test asserting the ember footer paints freq + sampled bin dB on hover and ignores the geometric payload.

### acceptance criteria
- [x] Cursor positioned along ember via mouse hover; readout shows freq (Hz) + amplitude (dB) with units/reference.
- [x] Amplitude reflects the drawn trace (sampled bin magnitude), follows gain/trim via the same frame data.
- [x] Ember restraint: dim footer line one row above the keytip strip, vanishes on mouse-out; crosshair is vertical-only.
- [x] Frequency snaps to / reports the actual FFT bin (`sample_spectrum_db_at_freq` picks nearest log bin; `▲` flags peak snap).
- [x] Out-of-trace / no-data → `—`, never a fabricated 0 dB.
- [ ] Live-rig verification (192.168.9.40) — left for QA; changes are display-only over existing frame data.

### test output
```
cargo test (workspace): all green
  ac-core   271 passed
  ac-cli     82 + 4 passed
  ac-daemon  63 + 47 passed
  ac-ui     232 passed   (6 new fmt cursor_readout tests + 1 new paint test)
clippy -D warnings: clean
cargo fmt --check: clean
```

### ac-daemon IPC schema changed
no

### new dependencies
none

### related
none — #153 (two-line bug) intentionally out of scope for this PR.

### open questions for reviewer
- The architect/UX notes assumed `cursor_readout`'s existing `Db` arm already sourced amplitude from `sampled_db`. It did not (the `Db` arm uses its geometric payload and ignored `sampled_db`). I therefore added the `SpectrumBin` variant rather than changing the shared `Db` arm, to avoid altering the regular `ViewMode::Spectrum` footer (out of scope). Flagging in case a different shape was expected.
- Vertical-only crosshair for ember is implemented per the UX spec ("no horizontal rule"). Other views keep the full crosshair.
- `needs-ux` / `ux-approved`: UX sign-off for #154 is already posted on #152; placement matches it (`bottom − 6 − STATUS_PX − 4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
