### PR TITLE
fix: cell-isolate ember substrate to stop grid leak (#153)

### DIFF
--- a/ac-rs/crates/ac-ui/src/app.rs
+++ b/ac-rs/crates/ac-ui/src/app.rs
@@ -300,6 +300,13 @@ pub struct App {
     spectrum: Option<SpectrumRenderer>,
     waterfall: Option<WaterfallRenderer>,
     pub(super) ember: Option<EmberRenderer>,
+    /// Last ember layout-generation key (hash of view_mode, layout, page,
+    /// visible channel set, and cell geometry). When it changes between
+    /// frames the substrate is force-cleared before the next deposit so a
+    /// prior configuration's phosphor cannot linger under the new one
+    /// (Single↔Grid / paging / channel-set / view switch). `None` until the
+    /// first ember frame. Fixes the grid-leak regression (#153).
+    pub(super) ember_layout_gen: Option<u64>,
     /// Phase 0a synthetic-sine generator state for `ViewMode::Scope`. Phase
     /// continuity matters: regenerating sine_phase from scratch each frame
     /// would cause audible-rate phase jumps between frames, visible as
@@ -622,6 +629,7 @@ impl App {
             spectrum: None,
             waterfall: None,
             ember: None,
+            ember_layout_gen: None,
             ember_sine_phase: 0.0,
             ember_last_tick: None,
             ember_scope_y_gain: 0.45,

--- a/ac-rs/crates/ac-ui/src/app/render_pipeline.rs
+++ b/ac-rs/crates/ac-ui/src/app/render_pipeline.rs
@@ -14,6 +14,7 @@ use crate::data::types::{
     CellView, DisplayFrame, FrameMeta, LayoutMode, SweepKind, TransferFrame, ViewMode,
 };
 use crate::render::context::RenderContext;
+use crate::render::ember::EmberScissor;
 use crate::render::grid;
 use crate::render::spectrum::{ChannelMeta, ChannelUpload};
 use crate::render::waterfall::CellUpload as WaterfallCellUpload;
@@ -1315,6 +1316,20 @@ impl App {
                 .clamp(0.0, 0.25);
             self.ember_last_tick = Some(now);
 
+            // Force-clear the substrate when the layout configuration changes
+            // so a prior config's phosphor cannot linger under the new one —
+            // the grid-leak / stale-trace regression (#153). The key folds in
+            // the active view, layout, and every visible cell's channel +
+            // geometry, so a Single↔Grid swap, a page turn, a channel-set
+            // change, or a view switch (e.g. scrolling Scope → static
+            // SpectrumEmber) all trip a clear. Persistence within one config is
+            // untouched: an unchanged key never clears.
+            let gen = ember_layout_generation(view_mode, self.config.layout, &cells);
+            if self.ember_layout_gen != Some(gen) {
+                ember.request_clear();
+                self.ember_layout_gen = Some(gen);
+            }
+
             match view_mode {
                 ViewMode::Scope => {
                     // Inlined `current_sr()` because `self.ember` is already
@@ -1347,6 +1362,7 @@ impl App {
                         &polyline,
                         scroll_dx,
                         dt,
+                        &[],
                     );
                 }
                 ViewMode::SpectrumEmber => {
@@ -1365,6 +1381,11 @@ impl App {
                     // carries the daemon's weighting / time integration
                     // AND the UI-side fractional-octave smoothing
                     // applied earlier in this method.
+                    // Per-cell scissor rects, populated only in Grid layout so
+                    // each channel's phosphor stays inside its own sub-rect of
+                    // the shared substrate (no cross-cell bleed, #153). Single
+                    // layout leaves this empty → whole-surface deposit + decay.
+                    let mut scissors: Vec<EmberScissor> = Vec::new();
                     let polyline: Vec<[f32; 3]> = if matches!(self.config.layout, LayoutMode::Grid)
                     {
                         // Cell-edge inset for the empty-cell border:
@@ -1407,6 +1428,7 @@ impl App {
                             // flip applied (`ember_cell_to_canvas_y`) for
                             // the baseline to land at each cell's own
                             // bottom edge.
+                            let start = combined.len() as u32;
                             if let Some(frame) = frame_opt {
                                 let mut local = build_ember_spectrum_trace(
                                     &frame.freqs,
@@ -1441,10 +1463,6 @@ impl App {
                                         ));
                                     }
                                 }
-                                combined.reserve(local.len());
-                                let zx = view.zoom_x;
-                                let zy = view.zoom_y;
-                                let zf = view.zoom.max(1e-3);
                                 // Focus emphasis: focused cell renders
                                 // at full deposit weight; non-focus
                                 // cells at 0.85× so the steady-state
@@ -1456,36 +1474,12 @@ impl App {
                                 } else {
                                     0.85
                                 };
-                                // Image zoom around the cursor anchor. At
-                                // zf=1 this is identity. For zf>1 points
-                                // are spread out around (zx, zy); pairs
-                                // entirely outside [0,1] are skipped so
-                                // zoomed content doesn't bleed into
-                                // neighbouring cells.
-                                for chunk in local.chunks_exact(2) {
-                                    let a = &chunk[0];
-                                    let b = &chunk[1];
-                                    let ax = zx + (a[0] - zx) * zf;
-                                    let ay = zy + (a[1] - zy) * zf;
-                                    let bx = zx + (b[0] - zx) * zf;
-                                    let by = zy + (b[1] - zy) * zf;
-                                    let in_bounds = |x: f32, y: f32| {
-                                        (0.0..=1.0).contains(&x) && (0.0..=1.0).contains(&y)
-                                    };
-                                    if !in_bounds(ax, ay) && !in_bounds(bx, by) {
-                                        continue;
-                                    }
-                                    combined.push([
-                                        cell.x + ax * cell.w,
-                                        ember_cell_to_canvas_y(ay, cell.y, cell.h),
-                                        a[2] * focus_w,
-                                    ]);
-                                    combined.push([
-                                        cell.x + bx * cell.w,
-                                        ember_cell_to_canvas_y(by, cell.y, cell.h),
-                                        b[2] * focus_w,
-                                    ]);
-                                }
+                                // Image zoom + clamp into this cell's canvas
+                                // rect. `ember_pack_cell` drops segments fully
+                                // outside the cell and clamps stragglers, so a
+                                // zoomed trace can never deposit a vertex into a
+                                // neighbouring cell (#153 leak #2).
+                                ember_pack_cell(&mut combined, &local, cell, &view, focus_w);
                             } else {
                                 // No data yet for this channel — mark the
                                 // clickable hitbox with four dim corner
@@ -1506,19 +1500,18 @@ impl App {
                                     EMBER_EMPTY_W,
                                 ));
                             }
+                            let end = combined.len() as u32;
+                            if end > start {
+                                scissors.push(EmberScissor {
+                                    rect_norm: [cell.x, cell.y, cell.w, cell.h],
+                                    range: [start, end],
+                                });
+                            }
                         }
                         combined
                     } else {
                         let active = self.config.active_channel;
                         let view = self.cell_views.get(active).copied().unwrap_or_default();
-                        // Single-mode image zoom: same per-cell
-                        // (zoom, zoom_x, zoom_y) state as Grid.
-                        // Polyline coords in cell-local [0,1] map
-                        // to canvas full-screen [0,1], so zoom
-                        // around the cursor anchor.
-                        let zx = view.zoom_x;
-                        let zy = view.zoom_y;
-                        let zf = view.zoom.max(1e-3);
                         let raw = frames
                             .get(active)
                             .and_then(|f| f.as_ref())
@@ -1556,30 +1549,21 @@ impl App {
                                 v
                             })
                             .unwrap_or_default();
+                        // Full-canvas Single cell `(0,0,1,1)` routed through the
+                        // same pack/flip path as Grid so the baseline lands at
+                        // the bottom edge in both layouts (the Single arm
+                        // formerly skipped the flip → mirrored second trace,
+                        // #148 / #153). One cell, no neighbour, so `scissors`
+                        // stays empty and the deposit covers the whole surface.
+                        let full = layout::CellRect {
+                            channel: active,
+                            x: 0.0,
+                            y: 0.0,
+                            w: 1.0,
+                            h: 1.0,
+                        };
                         let mut transformed: Vec<[f32; 3]> = Vec::with_capacity(raw.len());
-                        for chunk in raw.chunks_exact(2) {
-                            let a = &chunk[0];
-                            let b = &chunk[1];
-                            let ax = zx + (a[0] - zx) * zf;
-                            let ay = zy + (a[1] - zy) * zf;
-                            let bx = zx + (b[0] - zx) * zf;
-                            let by = zy + (b[1] - zy) * zf;
-                            let in_bounds = |x: f32, y: f32| {
-                                (0.0..=1.0).contains(&x) && (0.0..=1.0).contains(&y)
-                            };
-                            if !in_bounds(ax, ay) && !in_bounds(bx, by) {
-                                continue;
-                            }
-                            // Full-canvas Single cell is (0.0, 1.0): route
-                            // y through the same floor flip the Grid arm
-                            // uses so the baseline lands at the bottom edge
-                            // in both layouts. Without this the Single trace
-                            // rendered mirrored versus Grid and read as a
-                            // second, inverted trace on a mono channel
-                            // (#148 / #153).
-                            transformed.push([ax, ember_cell_to_canvas_y(ay, 0.0, 1.0), a[2]]);
-                            transformed.push([bx, ember_cell_to_canvas_y(by, 0.0, 1.0), b[2]]);
-                        }
+                        ember_pack_cell(&mut transformed, &raw, &full, &view, 1.0);
                         transformed
                     };
                     // tau_p 1.2 s — short enough that an old peak's
@@ -1599,6 +1583,7 @@ impl App {
                         &polyline,
                         0.0,
                         dt,
+                        &scissors,
                     );
                 }
                 ViewMode::Goniometer => {
@@ -1651,6 +1636,7 @@ impl App {
                         &polyline,
                         0.0,
                         dt,
+                        &[],
                     );
                 }
                 ViewMode::IoTransfer => {
@@ -1696,6 +1682,7 @@ impl App {
                         &polyline,
                         0.0,
                         dt,
+                        &[],
                     );
                 }
                 ViewMode::BodeMag => {
@@ -1726,6 +1713,7 @@ impl App {
                         &polyline,
                         0.0,
                         dt,
+                        &[],
                     );
                 }
                 ViewMode::Coherence => {
@@ -1748,6 +1736,7 @@ impl App {
                         &polyline,
                         0.0,
                         dt,
+                        &[],
                     );
                 }
                 ViewMode::BodePhase => {
@@ -1774,6 +1763,7 @@ impl App {
                         &polyline,
                         0.0,
                         dt,
+                        &[],
                     );
                 }
                 ViewMode::GroupDelay => {
@@ -1800,6 +1790,7 @@ impl App {
                         &polyline,
                         0.0,
                         dt,
+                        &[],
                     );
                 }
                 ViewMode::Nyquist => {
@@ -1842,6 +1833,7 @@ impl App {
                         &polyline,
                         0.0,
                         dt,
+                        &[],
                     );
                 }
                 ViewMode::Ir => {
@@ -1881,6 +1873,7 @@ impl App {
                         &polyline,
                         0.0,
                         dt,
+                        &[],
                     );
                 }
                 _ => {}
@@ -2358,6 +2351,83 @@ const EMBER_TRACE_FULL: f32 = 0.90;
 #[inline]
 fn ember_cell_to_canvas_y(ay: f32, cell_y: f32, cell_h: f32) -> f32 {
     1.0 - cell_y - ay * cell_h
+}
+
+/// Transform a cell-local ember LineList (`[x, y, w]` in `[0,1]`) into
+/// canvas space for `cell`, applying the per-cell image zoom and **clamping
+/// every emitted vertex into the cell rect** so a zoomed trace cannot deposit
+/// outside its own cell — the cross-cell bleed half of the grid-leak
+/// regression (#153 leak #2). Segments with both endpoints outside the cell
+/// frame are dropped; a segment straddling the edge keeps its inside endpoint
+/// and clamps the straggler to the boundary. Every appended vertex therefore
+/// satisfies `x ∈ [cell.x, cell.x+cell.w]` and `y ∈ [1-cell.y-cell.h,
+/// 1-cell.y]`. `focus_w` scales the deposit weight (focused cell 1.0, others
+/// dimmer). The y-flip (`ember_cell_to_canvas_y`) anchors the baseline at the
+/// cell floor in every layout.
+fn ember_pack_cell(
+    out: &mut Vec<[f32; 3]>,
+    local: &[[f32; 3]],
+    cell: &layout::CellRect,
+    view: &CellView,
+    focus_w: f32,
+) {
+    let zx = view.zoom_x;
+    let zy = view.zoom_y;
+    let zf = view.zoom.max(1e-3);
+    out.reserve(local.len());
+    for chunk in local.chunks_exact(2) {
+        let a = &chunk[0];
+        let b = &chunk[1];
+        let ax = zx + (a[0] - zx) * zf;
+        let ay = zy + (a[1] - zy) * zf;
+        let bx = zx + (b[0] - zx) * zf;
+        let by = zy + (b[1] - zy) * zf;
+        let in_bounds = |x: f32, y: f32| (0.0..=1.0).contains(&x) && (0.0..=1.0).contains(&y);
+        if !in_bounds(ax, ay) && !in_bounds(bx, by) {
+            continue;
+        }
+        let cl = |v: f32| v.clamp(0.0, 1.0);
+        let (ax, ay, bx, by) = (cl(ax), cl(ay), cl(bx), cl(by));
+        out.push([
+            cell.x + ax * cell.w,
+            ember_cell_to_canvas_y(ay, cell.y, cell.h),
+            a[2] * focus_w,
+        ]);
+        out.push([
+            cell.x + bx * cell.w,
+            ember_cell_to_canvas_y(by, cell.y, cell.h),
+            b[2] * focus_w,
+        ]);
+    }
+}
+
+/// Hash the ember layout configuration into a generation key. The key changes
+/// iff the active view, layout mode, or any visible cell's channel/geometry
+/// changes — i.e. on a Single↔Grid swap, a grid page turn, a channel-set
+/// change, a resize, or a view switch. `redraw` clears the substrate whenever
+/// this differs from the previous frame's key so a stale configuration's
+/// phosphor cannot bleed under the new one (#153 leak #1/#3). Persistence
+/// within one configuration is preserved: an unchanged key never clears.
+fn ember_layout_generation(
+    view_mode: ViewMode,
+    layout: LayoutMode,
+    cells: &[layout::CellRect],
+) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    std::mem::discriminant(&view_mode).hash(&mut h);
+    std::mem::discriminant(&layout).hash(&mut h);
+    (cells.len() as u64).hash(&mut h);
+    for cell in cells {
+        (cell.channel as u64).hash(&mut h);
+        // f32 has no Hash; fold the bit patterns so geometry changes (resize,
+        // page, layout) move the key.
+        cell.x.to_bits().hash(&mut h);
+        cell.y.to_bits().hash(&mut h);
+        cell.w.to_bits().hash(&mut h);
+        cell.h.to_bits().hash(&mut h);
+    }
+    h.finish()
 }
 
 /// Faint, constant deposit weight for an idle cell's hitbox marker. Dimmer
@@ -4575,5 +4645,169 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ---- Grid-leak isolation (#153) ----
+    //
+    // A grid cell's ember must stay inside its own rect: a zoomed trace may
+    // not deposit into a neighbour (leak #2), and the layout-generation key
+    // must change on any config switch so the substrate clears and a stale
+    // configuration cannot linger under the new one (leak #1 / #3).
+
+    /// A heavily-zoomed view pushes parts of the trace outside the cell-local
+    /// frame; `ember_pack_cell` must clamp/drop so every canvas vertex stays
+    /// within the cell rect — no bleed across the seam.
+    #[test]
+    fn ember_pack_cell_contains_zoomed_trace_in_cell() {
+        let cell = layout::CellRect {
+            channel: 1,
+            x: 0.5,
+            y: 0.5,
+            w: 0.5,
+            h: 0.5,
+        };
+        // Zoom 2× around the cell centre — spreads the trace past the cell-
+        // local [0,1] frame on both axes (exercising the clamp/drop path)
+        // while the central span still lands in-bounds (non-empty output).
+        let view = CellView {
+            zoom: 2.0,
+            zoom_x: 0.5,
+            zoom_y: 0.5,
+            ..CellView::default()
+        };
+        // Connected polyline sweeping x across the frame, y oscillating about
+        // the anchor so segments straddle every edge.
+        let cols: Vec<[f32; 3]> = (0..64)
+            .map(|i| {
+                let t = i as f32 / 63.0;
+                [t, 0.5 + 0.2 * (t * 6.0).sin(), EMBER_LIVE_W]
+            })
+            .collect();
+        let mut local = Vec::new();
+        for w in cols.windows(2) {
+            local.push(w[0]);
+            local.push(w[1]);
+        }
+        let mut out = Vec::new();
+        ember_pack_cell(&mut out, &local, &cell, &view, 1.0);
+        assert!(!out.is_empty(), "zoomed trace produced no vertices");
+
+        let x_lo = cell.x;
+        let x_hi = cell.x + cell.w;
+        let y_lo = 1.0 - cell.y - cell.h;
+        let y_hi = 1.0 - cell.y;
+        for p in &out {
+            assert!(
+                p[0] >= x_lo - 1e-5 && p[0] <= x_hi + 1e-5,
+                "vertex x {} escaped cell x-range [{x_lo}, {x_hi}] — cross-cell bleed",
+                p[0],
+            );
+            assert!(
+                p[1] >= y_lo - 1e-5 && p[1] <= y_hi + 1e-5,
+                "vertex y {} escaped cell y-range [{y_lo}, {y_hi}] — cross-cell bleed",
+                p[1],
+            );
+        }
+    }
+
+    /// Two adjacent grid cells, each packed with a trace zoomed toward the
+    /// shared seam: no vertex from one cell may land in the other's rect.
+    #[test]
+    fn ember_grid_cells_do_not_bleed_into_neighbours() {
+        let c0 = layout::CellRect {
+            channel: 0,
+            x: 0.0,
+            y: 0.0,
+            w: 0.5,
+            h: 1.0,
+        };
+        let c1 = layout::CellRect {
+            channel: 1,
+            x: 0.5,
+            y: 0.0,
+            w: 0.5,
+            h: 1.0,
+        };
+        // Zoom 2× about the cell centre pushes the trace's flanks past the
+        // cell-local frame — the clamp must keep every vertex on its own side
+        // of the x=0.5 seam.
+        let view = CellView {
+            zoom: 2.0,
+            zoom_x: 0.5,
+            zoom_y: 0.5,
+            ..CellView::default()
+        };
+        let cols: Vec<[f32; 3]> = (0..64)
+            .map(|i| {
+                let t = i as f32 / 63.0;
+                [t, 0.5 + 0.2 * (t * 6.0).sin(), EMBER_LIVE_W]
+            })
+            .collect();
+        let local: Vec<[f32; 3]> = cols.windows(2).flat_map(|w| [w[0], w[1]]).collect();
+
+        let mut o0 = Vec::new();
+        ember_pack_cell(&mut o0, &local, &c0, &view, 1.0);
+        let mut o1 = Vec::new();
+        ember_pack_cell(&mut o1, &local, &c1, &view, 1.0);
+        assert!(
+            !o0.is_empty() && !o1.is_empty(),
+            "expected vertices in both cells"
+        );
+
+        // Interior-of-rect test on x (the cells split horizontally at x=0.5).
+        let interior_x =
+            |p: &[f32; 3], c: &layout::CellRect| p[0] > c.x + 1e-4 && p[0] < c.x + c.w - 1e-4;
+        for p in &o0 {
+            assert!(!interior_x(p, &c1), "cell0 vertex {p:?} bled into cell1");
+        }
+        for p in &o1 {
+            assert!(!interior_x(p, &c0), "cell1 vertex {p:?} bled into cell0");
+        }
+    }
+
+    /// The layout-generation key must change on every config transition that
+    /// requires a substrate clear, and stay constant for an unchanged config.
+    #[test]
+    fn ember_layout_generation_distinguishes_configs() {
+        let cell = |channel: usize, x: f32, h: f32| layout::CellRect {
+            channel,
+            x,
+            y: 0.0,
+            w: 0.5,
+            h,
+        };
+        let cells_a = vec![cell(0, 0.0, 1.0)];
+        let cells_b = vec![cell(0, 0.0, 0.5), cell(1, 0.5, 0.5)];
+
+        let base = ember_layout_generation(ViewMode::SpectrumEmber, LayoutMode::Single, &cells_a);
+        // Identical config → identical key (persistence is preserved).
+        assert_eq!(
+            base,
+            ember_layout_generation(ViewMode::SpectrumEmber, LayoutMode::Single, &cells_a),
+        );
+        // Layout swap Single↔Grid.
+        assert_ne!(
+            base,
+            ember_layout_generation(ViewMode::SpectrumEmber, LayoutMode::Grid, &cells_a),
+        );
+        // View switch (e.g. scrolling Scope → static SpectrumEmber).
+        assert_ne!(
+            base,
+            ember_layout_generation(ViewMode::Scope, LayoutMode::Single, &cells_a),
+        );
+        // Channel-set / cell-count change (grid paging).
+        assert_ne!(
+            base,
+            ember_layout_generation(ViewMode::SpectrumEmber, LayoutMode::Single, &cells_b),
+        );
+        // Geometry change (resize) at the same channel set.
+        assert_ne!(
+            base,
+            ember_layout_generation(
+                ViewMode::SpectrumEmber,
+                LayoutMode::Single,
+                &[cell(0, 0.0, 0.5)],
+            ),
+        );
     }
 }

--- a/ac-rs/crates/ac-ui/src/render/ember.rs
+++ b/ac-rs/crates/ac-ui/src/render/ember.rs
@@ -30,6 +30,24 @@ const LUT_PALETTES: u32 = 2;
 #[allow(dead_code)]
 pub const PALETTE_NAMES: &[&str] = &["blackbody", "warm"];
 
+/// One grid cell's containment region for a single `advance` call: a scissor
+/// rect plus the half-open vertex range `[start, end)` that deposits into it.
+///
+/// `rect_norm` is the cell's canvas rect `[x, y, w, h]` in surface-normalised
+/// `[0,1]` coords (`y` bottom-up, matching the layout). `advance` converts it
+/// to texture pixels and scissors both the decay and deposit passes so each
+/// cell's phosphor stays inside its own sub-rect of the shared substrate —
+/// deposit splatter and decay cannot cross the dark seam into a neighbour
+/// (grid-leak fix, #153). `range` indexes the flat `line_pairs` slice in
+/// vertices; the deposit pass draws only that cell's segments under its
+/// scissor. An empty `scissors` slice falls back to whole-surface decay +
+/// deposit (the single-cell behaviour every non-grid ember view uses).
+#[derive(Debug, Clone, Copy)]
+pub struct EmberScissor {
+    pub rect_norm: [f32; 4],
+    pub range: [u32; 2],
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 struct DecayU {
@@ -453,6 +471,10 @@ impl EmberRenderer {
     /// `scroll_dx_norm` ∈ [0,1] shifts the existing substrate leftward by
     /// that fraction of its width before depositing — pass 0.0 for a static
     /// view (e.g. spectrum), `dt / window_s` for a strip-chart scope.
+    /// `scissors` contains the substrate to per-cell sub-rects: when
+    /// non-empty, the decay and deposit passes run once per `EmberScissor`
+    /// under its scissor rect, so a grid cell's phosphor cannot bleed into a
+    /// neighbour (#153). Pass `&[]` for the whole-surface single-cell views.
     #[allow(clippy::too_many_arguments)]
     pub fn advance(
         &mut self,
@@ -463,6 +485,7 @@ impl EmberRenderer {
         line_pairs: &[[f32; 3]],
         scroll_dx_norm: f32,
         dt: f32,
+        scissors: &[EmberScissor],
     ) {
         let dt = dt.clamp(0.0, 0.25);
 
@@ -523,7 +546,36 @@ impl EmberRenderer {
             );
         }
 
-        // Decay pass: src → dst.
+        // Per-cell scissor rects in texture pixels (origin top-left), paired
+        // with the clamped vertex range to deposit under each. A cell's canvas
+        // rect [x..x+w] × [y..y+h] (y bottom-up) maps to texture rows
+        // [y*H .. (y+h)*H]: the deposit shader's y-flip and the framebuffer's
+        // top-left origin cancel, so the normalised y is used directly. Rounds
+        // to integer pixels and clamps to the substrate bounds; degenerate
+        // (zero-area) rects are dropped.
+        let px_scissors: Vec<([u32; 4], [u32; 2])> = scissors
+            .iter()
+            .filter_map(|s| {
+                let r = s.rect_norm;
+                let x = (r[0] * TEX_W as f32).round().clamp(0.0, TEX_W as f32) as u32;
+                let y = (r[1] * TEX_H as f32).round().clamp(0.0, TEX_H as f32) as u32;
+                let w =
+                    ((r[2] * TEX_W as f32).round().max(0.0) as u32).min(TEX_W.saturating_sub(x));
+                let h =
+                    ((r[3] * TEX_H as f32).round().max(0.0) as u32).min(TEX_H.saturating_sub(y));
+                if w == 0 || h == 0 {
+                    return None;
+                }
+                let start = s.range[0].min(used as u32);
+                let end = s.range[1].min(used as u32).max(start);
+                Some(([x, y, w, h], [start, end]))
+            })
+            .collect();
+
+        // Decay pass: src → dst. The Clear load op wipes the whole target, so
+        // when scissoring per cell every region outside a cell rect is forced
+        // to black each frame (the unlit seam between cells); the decayed src
+        // is rewritten only inside each cell.
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("ember decay pass"),
@@ -541,7 +593,14 @@ impl EmberRenderer {
             });
             pass.set_pipeline(&self.decay_pipeline);
             pass.set_bind_group(0, src_view_for_decay_bg, &[]);
-            pass.draw(0..4, 0..1);
+            if px_scissors.is_empty() {
+                pass.draw(0..4, 0..1);
+            } else {
+                for (rect, _) in &px_scissors {
+                    pass.set_scissor_rect(rect[0], rect[1], rect[2], rect[3]);
+                    pass.draw(0..4, 0..1);
+                }
+            }
         }
 
         // Deposit pass: additive into dst (which now holds decayed values).
@@ -563,7 +622,17 @@ impl EmberRenderer {
             pass.set_pipeline(&self.deposit_pipeline);
             pass.set_bind_group(0, &self.deposit_bg, &[]);
             pass.set_vertex_buffer(0, self.point_vbuf.slice(..));
-            pass.draw(0..used as u32, 0..1);
+            if px_scissors.is_empty() {
+                pass.draw(0..used as u32, 0..1);
+            } else {
+                for (rect, range) in &px_scissors {
+                    if range[1] <= range[0] {
+                        continue;
+                    }
+                    pass.set_scissor_rect(rect[0], rect[1], rect[2], rect[3]);
+                    pass.draw(range[0]..range[1], 0..1);
+                }
+            }
         }
 
         self.front_is_latest = !self.front_is_latest;


### PR DESCRIPTION
closes #153

### what changed
The single-trace fix shipped in #156, but the owner then reported a deeper regression — *"spectrum completely useless, grid leaks to same view."* Implements the architect's revised **Option A**: keep the proven GPU phosphor substrate, rewrite the brittle layout/compositing layer that packed every grid cell into one shared full-surface texture with a single global decay and a one-time-only clear. Each cell is now contained to its own sub-rect, and the substrate is force-cleared whenever the layout configuration changes.

Addresses all three leaks the architect identified:
- **#2 zoom bleed** — `ember_pack_cell` clamps each cell's zoomed trace into its own canvas rect, so no vertex deposits outside the cell (CPU-side, unit-tested).
- **#1 stale phosphor across config changes** — `ember_layout_generation` hashes view/layout/page/channel-set/cell-geometry; `redraw` force-clears the substrate when the key changes.
- **#3 global decay/scroll afterglow** — a view switch (e.g. scrolling Scope → static SpectrumEmber) trips the same generation clear, and `EmberRenderer::advance` now scissors the decay + deposit passes per cell so phosphor cannot cross the dark seam.

### files touched
- `ac-rs/crates/ac-ui/src/render/ember.rs` — new `EmberScissor` struct; `advance` gains a `scissors` param and scissors the decay + deposit passes per cell (empty slice = legacy whole-surface path for non-grid views).
- `ac-rs/crates/ac-ui/src/app/render_pipeline.rs` — extracted the SpectrumEmber packing into `ember_pack_cell` (zoom + clamp into the cell rect) used by both Single and Grid; build the per-cell scissor list in the Grid arm; added `ember_layout_generation` + the generation-key clear before the ember dispatch; 3 new unit tests. The other 9 ember `advance` call sites pass `&[]`.
- `ac-rs/crates/ac-ui/src/app.rs` — new `ember_layout_gen: Option<u64>` state field.

### test output
```
ac-ui: 238 passed; 0 failed
workspace: 705 passed; 0 failed; 3 ignored
cargo clippy --workspace --all-targets -- -D warnings: clean
cargo fmt --check: clean
```
New tests (AC #3 — single-trace/isolation invariants pinned so the regression can't silently return):
- `ember_pack_cell_contains_zoomed_trace_in_cell` — a zoomed trace never escapes its cell rect.
- `ember_grid_cells_do_not_bleed_into_neighbours` — no vertex from one cell lands in a neighbour's rect.
- `ember_layout_generation_distinguishes_configs` — the gen key changes on layout/view/page/geometry change and is stable otherwise.

### ZMQ schema changed
no — SpectrumEmber consumes the existing `spectrum` frame; nothing published to `ds` changes.

### new dependencies
none

### related
none

### open questions for reviewer
- **AC #4 (live-rig verification) is not covered here** — scissor + clear are GPU-side and not exercisable in CPU/CI tests. Needs a manual pass against the rig (192.168.9.40) or a recorded multi-channel blob: confirm a 4-channel grid shows each cell as an isolated ember, no cross-cell bleed, and that switching Single↔Grid / paging / Scope→SpectrumEmber starts from black.
- **Decay scissoring forces non-cell regions (seams, plot margins) to black every frame** via the decay pass's clear load-op. This is the intended "unlit seam," but flagging in case any future ember view relies on inter-cell texture content persisting.
- Per the architect, true per-cell decay lifecycles (independent τ_p per cell) remain out of scope — Option B follow-up if ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)