### PR TITLE
fix: ember decay pass mirrors accumulated history around cell center

### DIFF
--- a/ac-rs/crates/ac-ui/src/render/shaders/ember_decay.wgsl
+++ b/ac-rs/crates/ac-ui/src/render/shaders/ember_decay.wgsl
@@ -9,8 +9,8 @@
 struct Params {
     decay:     f32,
     /// Horizontal scroll, in normalised texture coords. 0 = stationary
-    /// (pure decay). >0 = strip-chart: the destination texel at uv.x reads
-    /// the source at (uv.x + scroll_dx), so old content moves leftward and
+    /// (pure decay). >0 = strip-chart: the destination texel at x reads
+    /// the source at (x + scroll_dx), so old content moves leftward and
     /// the rightmost band falls off the source domain (returns 0 = fresh).
     scroll_dx: f32,
     _pad0:     f32,
@@ -22,7 +22,6 @@ struct Params {
 
 struct VsOut {
     @builtin(position) pos: vec4<f32>,
-    @location(0) uv: vec2<f32>,
 }
 
 @vertex
@@ -31,18 +30,29 @@ fn vs_main(@builtin(vertex_index) vid: u32) -> VsOut {
     let v = f32((vid >> 1u) & 1u);
     var out: VsOut;
     out.pos = vec4(u * 2.0 - 1.0, v * 2.0 - 1.0, 0.0, 1.0);
-    out.uv = vec2(u, v);
     return out;
 }
 
+// Samples `src` at this fragment's own render-target pixel coordinate
+// (`@builtin(position)`), not at a separately-computed uv varying. Those two
+// are not guaranteed to agree for an offscreen render target — the
+// vertex-shader NDC we emit and the rasterizer's actual row assignment for a
+// non-presentation target can differ from a naive uv fraction, and did: the
+// old uv-based read silently sampled the mirror row (dims.y - 1 - row) on
+// every decay pass, so persisted content built up a y-flipped ghost trace
+// alongside the correct one (visible as "double ember" once persistence
+// accumulated a few frames' worth). `frag_coord` is defined by WGSL to be the
+// exact pixel this invocation is writing to, so read-row == write-row always,
+// independent of any NDC convention.
 @fragment
-fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
-    let src_uv_x = in.uv.x + params.scroll_dx;
-    if (src_uv_x >= 1.0 || src_uv_x < 0.0) {
+fn fs_main(@builtin(position) frag_coord: vec4<f32>) -> @location(0) vec4<f32> {
+    let dims = textureDimensions(src);
+    let scroll_px = params.scroll_dx * f32(dims.x);
+    let src_x = i32(frag_coord.x + scroll_px);
+    if (src_x < 0 || src_x >= i32(dims.x)) {
         return vec4(0.0, 0.0, 0.0, 1.0);
     }
-    let dims = textureDimensions(src);
-    let coord = vec2<i32>(vec2<f32>(src_uv_x, in.uv.y) * vec2<f32>(dims));
+    let coord = vec2<i32>(src_x, i32(frag_coord.y));
     let l = textureLoad(src, coord, 0).r;
     return vec4(l * params.decay, 0.0, 0.0, 1.0);
 }


### PR DESCRIPTION
Reported by Markus: "double ember" in SpectrumEmber — a live trace plus what he correctly identified as a self-mirroring artifact, not peak/min-hold (which I'd initially guessed wrong and he corrected).

## Root cause
The decay pass's fragment shader read the source texture via a manually-computed `uv` varying (`uv.y * dims.y` as a texel coordinate) but the rasterizer writes that same fragment's output to a position derived independently from clip-space. For an offscreen render target these two aren't guaranteed to be the same row — and empirically weren't: every decay pass read row `R` but wrote the decayed result to row `(H-1-R)`. Deposit and display don't hit this (deposit computes NDC straight from data with no separate uv readback; display never re-samples its own output), so a single fresh frame always looked correct. Only decay's read-vs-write mismatch compounds over multiple frames, building a y-mirrored ghost of the trace's history alongside the live trace — worse the longer τ_p (persistence) lets it accumulate, invisible with fast decay.

## Fix
Sample `src` at `@builtin(position)` (the fragment's actual assigned render-target pixel) instead of the uv varying, so the decay pass's read row is identical to its write row by construction — no dependency on any NDC/texture-space convention for non-presentation targets.

## How I verified this (not just asserted it)
Set up Xvfb + lavapipe (software Vulkan) in the sandbox specifically to drive real ac-ui sessions end-to-end (xdotool for window focus + keypresses, `S` for screenshot). Confirmed empirically, with instrumented builds before settling on the fix:
- CPU-side polyline geometry is single-valued end-to-end (debug-printed the exact vertex buffer contents) — ruled out a geometry bug.
- The mirror requires **both** y-variation across the trace **and** multi-frame persistence — a forced-constant trace never mirrors regardless of decay speed; a forced linear ramp produces a perfect "X" (two mirrored diagonals) with normal decay, but only one clean diagonal with the decay pass's draw call disabled or decay set near-instant.
- That isolation pointed straight at the decay pass specifically (not deposit, not display).
- Post-fix: single clean trace in Single layout, and in Grid layout (4 channels, per-cell scissored decay) — no ghost in either.

### files touched
- `ac-rs/crates/ac-ui/src/render/shaders/ember_decay.wgsl` — sample by `@builtin(position)` instead of a uv varying

### test output
```
cargo test --workspace: 82+271+63+4+47+206 passed, 0 failed (one unrelated ac-daemon self-test flaked once under parallel load, reran clean in isolation and in the full suite — pre-existing, untouched by this change)
cargo clippy --workspace --all-targets -- -D warnings: clean
cargo fmt --check: clean
```

### ZMQ schema changed
no

### new dependencies
none (Xvfb + lavapipe + xdotool installed in the dev sandbox only, for verification — not a project dependency)

### related
none