### PR TITLE
feat: display-truth verification harness (T2/T3) for ac test software

### DIFF
--- a/.agents/qa.md
+++ b/.agents/qa.md
@@ -259,3 +259,11 @@ wrong without any test catching it. These are the highest priority.}
 - Do not flag style preferences as correctness issues. Clippy is the style arbiter.
 - If you find a bug outside the PR's scope, open a new issue — do not block this PR for it.
 - One review comment per PR pass. If the developer pushes a fix, do a second pass.
+- Do not approve a value-display PR (any PR that changes what gets rendered to
+  screen: spectrum/waterfall/ember/scope trace data, axis calibration, or the
+  post-receiver display buffer feeding them) without the display-truth harness
+  (`ac test software`'s T2/T3 checks, `ac-ui --headless-test`, #170) reporting
+  green for the invariants that apply to the changed view. A PR that only
+  changes internal correctness checks (CSV export, cursor readout) while the
+  harness is red is not `qa-approved` — that gap is exactly what #170 exists
+  to close.

--- a/ac-rs/crates/ac-cli/src/commands/test.rs
+++ b/ac-rs/crates/ac-cli/src/commands/test.rs
@@ -1,8 +1,22 @@
+use std::net::TcpListener;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
 use super::{check_ack, get_cal, level_to_dbfs};
 use crate::client::AcClient;
 use crate::io;
 use crate::parse::CommandKind;
+use crate::spawn::find_binary;
 
+/// `ac test software` — the daemon-side numeric self-test (unchanged),
+/// plus the display-truth harness (#170): spawns an isolated
+/// `ac-daemon --fake-audio` + `ac-ui --headless-test` pair (never the
+/// caller's own daemon, which may be talking to real hardware) and prints
+/// its T2/T3 results in the same table. Exits nonzero if anything failed —
+/// this is the CI-equivalent gate value-display PRs are meant to pass
+/// before `qa-approved` (handoff.md acceptance criteria).
 pub fn run_software(client: &mut AcClient) {
     let ack = check_ack(
         client.send_cmd(&serde_json::json!({"cmd": "test_software"}), None),
@@ -11,16 +25,209 @@ pub fn run_software(client: &mut AcClient) {
     println!("\n  Software self-test");
     println!("  {}", "\u{2500}".repeat(40));
 
+    let mut all_pass = ack
+        .get("all_pass")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     if let Some(results) = ack.get("results").and_then(|v| v.as_array()) {
-        for r in results {
-            let name = r.get("name").and_then(|v| v.as_str()).unwrap_or("?");
-            let pass = r.get("pass").and_then(|v| v.as_bool()).unwrap_or(false);
-            let mark = if pass { "PASS" } else { "FAIL" };
-            let detail = r.get("detail").and_then(|v| v.as_str()).unwrap_or("");
-            println!("  [{mark}]  {name}  {detail}");
-        }
+        print_rows(results);
     }
     println!();
+
+    println!(
+        "  Display-truth harness (T2/T3, #170 — fake-audio only, never touches real hardware)"
+    );
+    println!("  {}", "\u{2500}".repeat(40));
+    let dt_results = run_display_truth_harness();
+    print_rows(&dt_results);
+    all_pass &= dt_results
+        .iter()
+        .all(|r| r.get("pass").and_then(Value::as_bool).unwrap_or(false));
+    println!();
+
+    if !all_pass {
+        std::process::exit(1);
+    }
+}
+
+fn print_rows(results: &[Value]) {
+    for r in results {
+        let name = r.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+        let pass = r.get("pass").and_then(|v| v.as_bool()).unwrap_or(false);
+        let mark = if pass { "PASS" } else { "FAIL" };
+        let detail = r.get("detail").and_then(|v| v.as_str()).unwrap_or("");
+        println!("  [{mark}]  {name}  {detail}");
+    }
+}
+
+/// Ask the OS for two free loopback ports so the harness's throwaway
+/// daemon can never collide with a real `ac-daemon` (or a second harness
+/// run) on the default 5556/5557 pair. Small bind-then-drop race, same
+/// idiom used for test-only port allocation elsewhere in this workspace;
+/// acceptable here since this is itself a test/dev-tooling code path.
+fn free_port_pair() -> std::io::Result<(u16, u16)> {
+    let a = TcpListener::bind("127.0.0.1:0")?;
+    let b = TcpListener::bind("127.0.0.1:0")?;
+    Ok((a.local_addr()?.port(), b.local_addr()?.port()))
+}
+
+fn fail_row(name: &str, detail: String) -> Vec<Value> {
+    vec![serde_json::json!({"name": name, "pass": false, "detail": detail})]
+}
+
+fn run_display_truth_harness() -> Vec<Value> {
+    let daemon_bin = match find_binary("ac-daemon") {
+        Some(p) => p,
+        None => return fail_row("display-truth harness", "ac-daemon binary not found".into()),
+    };
+    let ui_bin = match find_binary("ac-ui") {
+        Some(p) => p,
+        None => return fail_row("display-truth harness", "ac-ui binary not found".into()),
+    };
+    let (ctrl_port, data_port) = match free_port_pair() {
+        Ok(p) => p,
+        Err(e) => {
+            return fail_row(
+                "display-truth harness",
+                format!("could not allocate loopback ports: {e}"),
+            )
+        }
+    };
+
+    let mut daemon = match Command::new(&daemon_bin)
+        .args([
+            "--local",
+            "--fake-audio",
+            "--ctrl-port",
+            &ctrl_port.to_string(),
+            "--data-port",
+            &data_port.to_string(),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return fail_row(
+                "display-truth harness",
+                format!("failed to spawn isolated ac-daemon: {e}"),
+            )
+        }
+    };
+
+    let ctrl_addr = format!("tcp://127.0.0.1:{ctrl_port}");
+    let data_addr = format!("tcp://127.0.0.1:{data_port}");
+    if let Err(e) = wait_for_daemon(&ctrl_addr) {
+        let _ = daemon.kill();
+        let _ = daemon.wait();
+        return fail_row(
+            "display-truth harness",
+            format!("isolated ac-daemon did not come up: {e}"),
+        );
+    }
+
+    let ui_output = Command::new(&ui_bin)
+        .args([
+            "--headless-test",
+            "--ctrl",
+            &ctrl_addr,
+            "--connect",
+            &data_addr,
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output();
+
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+
+    let output = match ui_output {
+        Ok(o) => o,
+        Err(e) => {
+            return fail_row(
+                "display-truth harness",
+                format!("failed to spawn ac-ui --headless-test: {e}"),
+            )
+        }
+    };
+
+    if !output.status.success() {
+        // A crash (e.g. a driver-level segfault in a software Vulkan
+        // stack — see the note at `headless::readback`'s `device.poll`
+        // call) exits non-zero with no JSON on stdout. Surface that
+        // distinctly rather than silently reporting zero checks as a
+        // pass, or trying to parse empty/partial JSON.
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let parsed: Option<Value> = serde_json::from_str(stdout.trim()).ok();
+        if let Some(v) = parsed {
+            if let Some(results) = v.get("results").and_then(|r| r.as_array()) {
+                return results.to_vec();
+            }
+        }
+        return fail_row(
+            "display-truth harness",
+            format!(
+                "ac-ui --headless-test exited with {:?} and no parseable result \
+                 (likely a GPU/driver-level crash under this host's Vulkan stack — \
+                 see runbook; T2 buffer checks may still be informative in its stderr log)",
+                output.status.code(),
+            ),
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    match serde_json::from_str::<Value>(stdout.trim()) {
+        Ok(v) => v
+            .get("results")
+            .and_then(|r| r.as_array())
+            .cloned()
+            .unwrap_or_else(|| {
+                fail_row(
+                    "display-truth harness",
+                    "no results field in ac-ui output".into(),
+                )
+            }),
+        Err(e) => fail_row(
+            "display-truth harness",
+            format!("could not parse ac-ui --headless-test output as JSON: {e}"),
+        ),
+    }
+}
+
+fn wait_for_daemon(ctrl_addr: &str) -> anyhow::Result<()> {
+    let ctx = zmq::Context::new();
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+        let Ok(s) = ctx.socket(zmq::REQ) else {
+            continue;
+        };
+        s.set_linger(0).ok();
+        s.set_rcvtimeo(300).ok();
+        s.set_sndtimeo(300).ok();
+        if s.connect(ctrl_addr).is_err() {
+            continue;
+        }
+        if s.send(
+            serde_json::json!({"cmd": "status"}).to_string().as_bytes(),
+            0,
+        )
+        .is_err()
+        {
+            continue;
+        }
+        if let Ok(reply) = s.recv_string(0) {
+            if let Ok(Ok(v)) = reply.map(|r| serde_json::from_str::<Value>(&r)) {
+                if v.get("ok").and_then(Value::as_bool) == Some(true) {
+                    return Ok(());
+                }
+            }
+        }
+    }
+    anyhow::bail!("no response within 3s")
 }
 
 pub fn run_hardware(cmd: &CommandKind, client: &mut AcClient) {

--- a/ac-rs/crates/ac-daemon/src/audio/fake.rs
+++ b/ac-rs/crates/ac-daemon/src/audio/fake.rs
@@ -21,10 +21,28 @@ use super::AudioEngine;
 /// never alias into the same FFT bin at common analysis lengths.
 const CHANNEL_OFFSET_HZ: f64 = 100.0;
 
+/// What `capture_block` / `capture_stereo` synthesize. `Tones` covers both
+/// the historical single-tone `set_tone` path and the multi-tone
+/// `set_tone_pair` path added for the display-truth harness (#170) — a
+/// single-element vec reproduces the old behaviour exactly. `Noise` is a
+/// deterministic pseudo-random broadband signal for the I2 flat-noise
+/// continuity invariant; deterministic (fixed LCG per channel offset) so
+/// harness runs are reproducible.
+#[derive(Clone)]
+enum Stimulus {
+    Tones(Vec<(f64, f64)>),
+    Noise(f64),
+}
+
+impl Default for Stimulus {
+    fn default() -> Self {
+        Stimulus::Tones(vec![(1_000.0, 0.0)])
+    }
+}
+
 pub struct FakeEngine {
     sample_rate: u32,
-    freq_hz: f64,
-    amplitude: f64,
+    stimulus: Stimulus,
     xruns: u32,
     output_ports: Vec<String>,
     input_port: Option<String>,
@@ -35,8 +53,7 @@ impl FakeEngine {
     pub fn new() -> Self {
         Self {
             sample_rate: 48_000,
-            freq_hz: 1_000.0,
-            amplitude: 0.0,
+            stimulus: Stimulus::default(),
             xruns: 0,
             output_ports: Vec::new(),
             input_port: None,
@@ -53,28 +70,76 @@ impl FakeEngine {
             .unwrap_or(0)
     }
 
-    fn effective_freq(&self, port: Option<&str>) -> f64 {
+    fn channel_offset_hz(port: Option<&str>) -> f64 {
         let ch = port.map(Self::channel_index).unwrap_or(0);
-        self.freq_hz + ch as f64 * CHANNEL_OFFSET_HZ
+        ch as f64 * CHANNEL_OFFSET_HZ
     }
 
-    /// Generate `duration` seconds of synthetic signal at the given frequency.
-    fn make_samples_at(&self, freq: f64, duration: f64) -> Vec<f32> {
+    /// Effective (channel-shifted) frequency of the first configured tone.
+    /// Test-only: multi-tone stimuli don't have one "the" frequency so
+    /// this only inspects `tones[0]`, which is enough for the single-tone
+    /// regression coverage below.
+    #[cfg(test)]
+    fn effective_freq(&self, port: Option<&str>) -> f64 {
+        let offset = Self::channel_offset_hz(port);
+        match &self.stimulus {
+            Stimulus::Tones(tones) => tones.first().map(|&(f, _)| f + offset).unwrap_or(0.0),
+            Stimulus::Noise(_) => offset,
+        }
+    }
+
+    /// Generate `duration` seconds of synthetic signal for `port`'s channel
+    /// (frequency-shifted per `CHANNEL_OFFSET_HZ`, same as pre-#170).
+    fn make_samples_for(&self, port: Option<&str>, duration: f64) -> Vec<f32> {
         let n = (self.sample_rate as f64 * duration) as usize;
-        let amp = if self.amplitude > 0.0 {
-            self.amplitude
-        } else {
-            0.1
-        };
+        let offset = Self::channel_offset_hz(port);
         let sr = self.sample_rate as f64;
-        (0..n)
-            .map(|i| {
-                let t = i as f64 / sr;
-                let sig =
-                    amp * (2.0 * PI * freq * t).sin() + amp * 0.01 * (4.0 * PI * freq * t).sin();
-                sig as f32
-            })
-            .collect()
+        match &self.stimulus {
+            Stimulus::Tones(tones) => {
+                // Historical default: nothing has set a nonzero amplitude
+                // yet → fall back to a 0.1-amplitude sine so `--fake-audio`
+                // produces plausible output out of the box (unchanged from
+                // pre-#170 behaviour).
+                let effective: Vec<(f64, f64)> = if tones.iter().all(|&(_, a)| a <= 0.0) {
+                    vec![(tones.first().map(|&(f, _)| f).unwrap_or(1_000.0), 0.1)]
+                } else {
+                    tones.clone()
+                };
+                (0..n)
+                    .map(|i| {
+                        let t = i as f64 / sr;
+                        let sig: f64 = effective
+                            .iter()
+                            .map(|&(freq, amp)| {
+                                let f = freq + offset;
+                                amp * (2.0 * PI * f * t).sin()
+                                    + amp * 0.01 * (4.0 * PI * f * t).sin()
+                            })
+                            .sum();
+                        sig as f32
+                    })
+                    .collect()
+            }
+            Stimulus::Noise(amp) => {
+                let amp = if *amp > 0.0 { *amp } else { 0.1 };
+                // Deterministic LCG, seeded from the channel offset so
+                // simultaneously-captured channels (meas/ref) don't share
+                // one sample sequence. Not spectrally flattened to true
+                // pink/white — good enough as a calibrated-amplitude
+                // broadband stimulus for I2, which checks for band-boundary
+                // steps rather than an exact spectral shape.
+                let mut state: u64 = 0x9E3779B97F4A7C15 ^ offset.to_bits();
+                (0..n)
+                    .map(|_| {
+                        state = state
+                            .wrapping_mul(6364136223846793005)
+                            .wrapping_add(1442695040888963407);
+                        let u = ((state >> 40) as f64 / (1u64 << 24) as f64) * 2.0 - 1.0;
+                        (amp * u) as f32
+                    })
+                    .collect()
+            }
+        }
     }
 }
 
@@ -92,22 +157,28 @@ impl AudioEngine for FakeEngine {
     }
 
     fn set_tone(&mut self, freq_hz: f64, amplitude: f64) {
-        self.freq_hz = freq_hz;
-        self.amplitude = amplitude;
+        self.stimulus = Stimulus::Tones(vec![(freq_hz, amplitude)]);
     }
 
     fn set_pink(&mut self, amplitude: f64) {
-        self.amplitude = amplitude;
+        self.stimulus = Stimulus::Noise(amplitude);
     }
 
     fn set_silence(&mut self) {
-        self.amplitude = 0.0;
+        self.stimulus = Stimulus::Tones(vec![(1_000.0, 0.0)]);
+    }
+
+    fn set_tone_pair(&mut self, tones: &[(f64, f64)]) {
+        self.stimulus = Stimulus::Tones(tones.to_vec());
+    }
+
+    fn set_broadband_noise(&mut self, amplitude: f64) {
+        self.stimulus = Stimulus::Noise(amplitude);
     }
 
     fn capture_block(&mut self, duration: f64) -> Result<Vec<f32>> {
         std::thread::sleep(Duration::from_secs_f64(duration));
-        let freq = self.effective_freq(self.input_port.as_deref());
-        Ok(self.make_samples_at(freq, duration))
+        Ok(self.make_samples_for(self.input_port.as_deref(), duration))
     }
 
     /// Fake loopback: returns `samples` delayed by a fixed number of
@@ -131,11 +202,9 @@ impl AudioEngine for FakeEngine {
 
     fn capture_stereo(&mut self, duration: f64) -> Result<(Vec<f32>, Vec<f32>)> {
         std::thread::sleep(Duration::from_secs_f64(duration));
-        let meas_freq = self.effective_freq(self.input_port.as_deref());
         // If no explicit ref_port, reference mirrors the generator (channel 0).
-        let ref_freq = self.effective_freq(self.ref_port.as_deref());
-        let meas = self.make_samples_at(meas_freq, duration);
-        let refch = self.make_samples_at(ref_freq, duration);
+        let meas = self.make_samples_for(self.input_port.as_deref(), duration);
+        let refch = self.make_samples_for(self.ref_port.as_deref(), duration);
         Ok((meas, refch))
     }
 
@@ -238,5 +307,60 @@ mod tests {
         assert_eq!(meas.len(), refch.len());
         let diff: f32 = meas.iter().zip(&refch).map(|(a, b)| (a - b).abs()).sum();
         assert!(diff > 0.0, "meas and ref channels should differ");
+    }
+
+    /// Goertzel magnitude at `freq` — enough to confirm energy landed where
+    /// a tone was requested without pulling in a full FFT for a unit test.
+    fn goertzel_mag(samples: &[f32], sr: f64, freq: f64) -> f64 {
+        let n = samples.len();
+        let k = (0.5 + (n as f64 * freq) / sr).floor();
+        let w = 2.0 * PI * k / n as f64;
+        let cw = w.cos();
+        let coeff = 2.0 * cw;
+        let (mut s1, mut s2) = (0.0_f64, 0.0_f64);
+        for &x in samples {
+            let s0 = x as f64 + coeff * s1 - s2;
+            s2 = s1;
+            s1 = s0;
+        }
+        (s1 * s1 + s2 * s2 - s1 * s2 * coeff).sqrt() / n as f64
+    }
+
+    #[test]
+    fn tone_pair_synthesizes_both_frequencies() {
+        // #170: I3/I1 stimulus needs two simultaneous tones at distinct
+        // levels — confirm both actually land in the captured signal, not
+        // just the first (the old `set_tone` single-tone behaviour).
+        let sr = 48_000;
+        let mut eng = FakeEngine::new();
+        eng.set_tone_pair(&[(1_000.0, 0.5), (5_000.0, 0.1)]);
+        let s = eng.capture_block(0.5).unwrap();
+        let m1 = goertzel_mag(&s, sr as f64, 1_000.0);
+        let m2 = goertzel_mag(&s, sr as f64, 5_000.0);
+        assert!(m1 > 0.1, "expected energy at 1000 Hz, got mag {m1}");
+        assert!(m2 > 0.01, "expected energy at 5000 Hz, got mag {m2}");
+        assert!(
+            m1 > m2,
+            "louder tone (0.5) should measure higher than quieter tone (0.1): {m1} vs {m2}"
+        );
+    }
+
+    #[test]
+    fn broadband_noise_has_no_dominant_tone() {
+        // #170: I2 stimulus needs genuine spectral content, not the old
+        // `set_pink` fallback (which only ever synthesized a sine).
+        let mut eng = FakeEngine::new();
+        eng.set_broadband_noise(0.5);
+        let s = eng.capture_block(0.5).unwrap();
+        assert!(!s.is_empty());
+        let rms: f64 = (s.iter().map(|x| (*x as f64).powi(2)).sum::<f64>() / s.len() as f64).sqrt();
+        assert!(rms > 0.05, "expected broadband energy, rms = {rms}");
+        // A single-bin Goertzel magnitude at any one frequency should be
+        // small relative to total RMS energy — noise, not a tone.
+        let m = goertzel_mag(&s, 48_000.0, 1_000.0) / s.len() as f64;
+        assert!(
+            m < rms,
+            "energy concentrated at 1000 Hz looks tonal, not broadband: mag/n={m} rms={rms}"
+        );
     }
 }

--- a/ac-rs/crates/ac-daemon/src/audio/mod.rs
+++ b/ac-rs/crates/ac-daemon/src/audio/mod.rs
@@ -133,6 +133,30 @@ pub trait AudioEngine: Send + 'static {
     fn backend_name(&self) -> &'static str {
         "unknown"
     }
+
+    /// Set continuous output as the sum of several simultaneous sine tones,
+    /// each `(freq_hz, amplitude)`. Used by the display-truth harness (#170)
+    /// to drive the I3 orientation invariant (two tones at distinct levels,
+    /// check the louder one renders higher). Default delegates to
+    /// `set_tone` with the first tone and drops the rest — only the fake
+    /// backend (test/`--fake-audio` use) needs true multi-tone synthesis;
+    /// real backends generating a single physical output tone is an
+    /// acceptable degradation since routing-dependent commands already gate
+    /// on `supports_routing`.
+    fn set_tone_pair(&mut self, tones: &[(f64, f64)]) {
+        if let Some(&(freq, amp)) = tones.first() {
+            self.set_tone(freq, amp);
+        }
+    }
+
+    /// Set continuous calibrated broadband noise at the given peak
+    /// amplitude (0..1 full-scale). Used by the display-truth harness
+    /// (#170) to drive the I2 flat-noise continuity invariant, which needs
+    /// genuine spectral content (not a single tone) to check for
+    /// band-boundary steps. Default delegates to `set_pink`.
+    fn set_broadband_noise(&mut self, amplitude: f64) {
+        self.set_pink(amplitude);
+    }
 }
 
 /// Build an audio engine: fake → JACK (if available) → CPAL (non-Linux only) → fake.

--- a/ac-rs/crates/ac-daemon/src/handlers/audio/monitor.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/audio/monitor.rs
@@ -255,9 +255,41 @@ impl ReconnectState {
     }
 }
 
+/// One tone in a `fake_tones` stimulus request — see `monitor_spectrum`.
+struct FakeTone {
+    freq_hz: f64,
+    level_dbfs: f64,
+}
+
+/// Full-scale dBFS → linear peak amplitude (0 dBFS = 1.0). Used only for
+/// the `--fake-audio` stimulus knobs below (#170 display-truth harness);
+/// real backends never see this.
+fn dbfs_to_amplitude(dbfs: f64) -> f64 {
+    10f64.powf(dbfs / 20.0)
+}
+
 pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
     busy_guard!(state, "monitor_spectrum");
     let freq_hz = cmd.get("freq_hz").and_then(Value::as_f64).unwrap_or(1000.0);
+    // Fake-audio-only stimulus knobs for the display-truth harness (#170,
+    // `ac test software`). Ignored entirely on real backends — the harness
+    // is required to never touch physical hardware, so these are only
+    // read/applied below when `state.fake_audio` is true.
+    let amplitude = cmd.get("amplitude").and_then(Value::as_f64).unwrap_or(0.0);
+    let fake_tones: Option<Vec<FakeTone>> =
+        cmd.get("fake_tones").and_then(Value::as_array).map(|arr| {
+            arr.iter()
+                .filter_map(|t| {
+                    let freq_hz = t.get("freq_hz").and_then(Value::as_f64)?;
+                    let level_dbfs = t.get("level_dbfs").and_then(Value::as_f64)?;
+                    Some(FakeTone {
+                        freq_hz,
+                        level_dbfs,
+                    })
+                })
+                .collect()
+        });
+    let fake_noise_dbfs = cmd.get("fake_noise_dbfs").and_then(Value::as_f64);
 
     let defaults = MonitorParams::default();
     let interval = cmd
@@ -359,6 +391,23 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                 &json!({"cmd":"monitor_spectrum","message":format!("{e}")}),
             );
             return;
+        }
+        // Apply the display-truth harness's stimulus knobs (#170) — fake
+        // backend only, real hardware is never touched by this command.
+        // Precedence when more than one is given: fake_tones > fake_noise_dbfs
+        // > freq_hz/amplitude single-tone (the pre-#170 default path).
+        if fake {
+            if let Some(tones) = &fake_tones {
+                let pairs: Vec<(f64, f64)> = tones
+                    .iter()
+                    .map(|t| (t.freq_hz, dbfs_to_amplitude(t.level_dbfs)))
+                    .collect();
+                eng.set_tone_pair(&pairs);
+            } else if let Some(noise_dbfs) = fake_noise_dbfs {
+                eng.set_broadband_noise(dbfs_to_amplitude(noise_dbfs));
+            } else {
+                eng.set_tone(freq_hz, amplitude);
+            }
         }
         let sr = eng.sample_rate();
         // Per-channel mic-curve FIRs for the loudness path (#104). One

--- a/ac-rs/crates/ac-daemon/tests/it_protocol.rs
+++ b/ac-rs/crates/ac-daemon/tests/it_protocol.rs
@@ -555,6 +555,134 @@ fn monitor_spectrum_wire_values_match_fake_tone() {
 }
 
 #[test]
+fn monitor_spectrum_fake_tones_produce_two_distinct_peaks() {
+    // #170 display-truth harness: `fake_tones` must actually reach the
+    // fake engine (via `dbfs_to_amplitude` + `set_tone_pair` in
+    // handlers/audio/monitor.rs) and produce two independently-detectable
+    // spectral peaks at their requested levels — the I1/I3 stimulus this
+    // harness needs. Frequencies chosen well clear of each other and of
+    // the LF/HF crossover so both land cleanly in one FFT.
+    let d = Daemon::spawn();
+    let c = Client::new(&d);
+
+    let r = c.call(json!({
+        "cmd": "monitor_spectrum",
+        "channels": [0],
+        "interval_ms": 100,
+        "fft_n": 8192,
+        "fake_tones": [
+            {"freq_hz": 2000.0, "level_dbfs": -6.0},
+            {"freq_hz": 9000.0, "level_dbfs": -24.0},
+        ],
+    }));
+    assert_eq!(r["ok"], json!(true), "monitor_spectrum ack: {r}");
+
+    let mut frame: Option<Value> = None;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut accepted = 0;
+    while Instant::now() < deadline {
+        let Some((topic, payload)) = c.recv_pub(2_000) else {
+            break;
+        };
+        if topic != "data"
+            || payload.get("type").and_then(Value::as_str) != Some("visualize/spectrum")
+        {
+            continue;
+        }
+        if payload
+            .get("spectrum")
+            .and_then(Value::as_array)
+            .is_none_or(|a| a.is_empty())
+        {
+            continue;
+        }
+        accepted += 1;
+        if accepted >= 2 {
+            frame = Some(payload);
+            break;
+        }
+    }
+    let _ = c.call(json!({"cmd": "stop"}));
+    let frame = frame.expect("no usable spectrum frame within 5 s");
+
+    let peaks = frame["peaks"].as_array().expect("peaks array");
+    let find = |target_hz: f64| {
+        peaks
+            .iter()
+            .filter_map(|v| v.as_array())
+            .find(|p| (p[0].as_f64().unwrap_or(0.0) - target_hz).abs() < 5.0)
+            .map(|p| p[1].as_f64().unwrap())
+    };
+    let p1 = find(2000.0).expect("peak near 2000 Hz");
+    let p2 = find(9000.0).expect("peak near 9000 Hz");
+    assert!(
+        (p1 - (-6.0)).abs() < 1.5,
+        "2000 Hz peak = {p1:.2} dBFS, want ~-6.0"
+    );
+    assert!(
+        (p2 - (-24.0)).abs() < 1.5,
+        "9000 Hz peak = {p2:.2} dBFS, want ~-24.0"
+    );
+    assert!(
+        p1 > p2,
+        "louder tone (-6 dBFS) must measure above quieter tone (-24 dBFS)"
+    );
+}
+
+#[test]
+fn monitor_spectrum_fake_noise_stays_bounded() {
+    // #170 I4 (bounded output): calibrated broadband noise stimulus must
+    // never produce a post-receiver value above 0 dBFS.
+    let d = Daemon::spawn();
+    let c = Client::new(&d);
+
+    let r = c.call(json!({
+        "cmd": "monitor_spectrum",
+        "channels": [0],
+        "interval_ms": 100,
+        "fft_n": 8192,
+        "fake_noise_dbfs": -20.0,
+    }));
+    assert_eq!(r["ok"], json!(true), "monitor_spectrum ack: {r}");
+
+    let mut frame: Option<Value> = None;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        let Some((topic, payload)) = c.recv_pub(2_000) else {
+            break;
+        };
+        if topic != "data"
+            || payload.get("type").and_then(Value::as_str) != Some("visualize/spectrum")
+        {
+            continue;
+        }
+        if let Some(spec) = payload.get("spectrum").and_then(Value::as_array) {
+            if !spec.is_empty() {
+                frame = Some(payload);
+                break;
+            }
+        }
+    }
+    let _ = c.call(json!({"cmd": "stop"}));
+    let frame = frame.expect("no usable spectrum frame within 5 s");
+    let spec = frame["spectrum"].as_array().expect("spectrum array");
+    let max = spec
+        .iter()
+        .filter_map(Value::as_f64)
+        .fold(f64::MIN, f64::max);
+    // Tolerance rationale: -20 dBFS peak-amplitude noise is 20 dB clear of
+    // 0 dBFS; a single FFT bin can still read a few hundredths of a dB
+    // above nominal from window-leakage constructive summation of random
+    // phase, so 1.0 dB catches a real gain/clamping bug (which produces
+    // multi-dB or +19 dB-class violations, see fixtures-spectrum-hf-garbage)
+    // without flagging that benign noise floor.
+    assert!(
+        max <= 1.0,
+        "noise stimulus produced a value above 0 dBFS + tolerance: max={max}"
+    );
+}
+
+#[test]
 fn monitor_spectrum_emits_scope_frames() {
     // unified.md Phase 0b: the daemon must emit a `visualize/scope`
     // sidecar frame per channel per tick alongside the spectrum frame.

--- a/ac-rs/crates/ac-ui/src/app/render_pipeline.rs
+++ b/ac-rs/crates/ac-ui/src/app/render_pipeline.rs
@@ -2084,7 +2084,11 @@ fn ember_cell_to_canvas_y(ay: f32, cell_y: f32, cell_h: f32) -> f32 {
 /// 1-cell.y]`. `focus_w` scales the deposit weight (focused cell 1.0, others
 /// dimmer). The y-flip (`ember_cell_to_canvas_y`) anchors the baseline at the
 /// cell floor in every layout.
-fn ember_pack_cell(
+/// `pub(crate)`: reused verbatim by the headless display-truth harness
+/// (#170, `ac test software`) so its T3 pixel checks exercise the exact
+/// same freq/dB → canvas-position transform SpectrumEmber renders with,
+/// not a reimplementation that could hide a bug both share.
+pub(crate) fn ember_pack_cell(
     out: &mut Vec<[f32; 3]>,
     local: &[[f32; 3]],
     cell: &layout::CellRect,
@@ -2379,7 +2383,9 @@ pub(crate) fn column_median(samples: &mut [f32]) -> Option<f32> {
 /// transfer frames without that aggregation step actually happening for the
 /// live magnitude trace — it wasn't; #163 fixed the scrambled-axis bug that
 /// exposed the gap between the claim and the code.)
-fn build_ember_spectrum_trace(
+/// `pub(crate)`: reused verbatim by the headless display-truth harness
+/// (#170) — see `ember_pack_cell` above for why this isn't reimplemented.
+pub(crate) fn build_ember_spectrum_trace(
     freqs: &[f32],
     mags: &[f32],
     view: &CellView,

--- a/ac-rs/crates/ac-ui/src/headless.rs
+++ b/ac-rs/crates/ac-ui/src/headless.rs
@@ -1,0 +1,991 @@
+//! Headless T2/T3 display-truth harness — `ac-ui --headless-test` (#170).
+//!
+//! Extends `ac test software` with checks between "the numbers are right"
+//! (T2: the post-receiver `DisplayFrame` buffer, exactly what `ChannelStore`
+//! hands the renderer) and "the screen is right" (T3: pixels read back from
+//! an offscreen wgpu texture rendered with the *real* `SpectrumRenderer` /
+//! `EmberRenderer` production paint code, under software Vulkan/lavapipe or
+//! `WGPU_BACKEND=gl`). See `handoff.md` at the repo root for the full I1-I4
+//! invariant rationale this module implements.
+//!
+//! Never touches real hardware itself — it only knows how to talk to
+//! whatever daemon endpoint it's given. `ac-cli`'s `run_software` is
+//! responsible for pointing it at an isolated `ac-daemon --fake-audio`
+//! subprocess (see `ac-cli/src/commands/test.rs`), never the user's
+//! possibly-real daemon.
+//!
+//! Runs no winit event loop, opens no window, creates no `wgpu::Surface` —
+//! `HeadlessGpu` requests a device directly from an adapter with
+//! `compatible_surface: None`.
+
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+
+use crate::app::render_pipeline::{build_ember_spectrum_trace, ember_pack_cell};
+use crate::data::control::CtrlClient;
+use crate::data::receiver;
+use crate::data::store::{
+    ChannelStore, LoudnessStore, ScopeStore, SweepStore, TransferStore, VirtualChannelStore,
+};
+use crate::data::types::{CellView, DisplayConfig, DisplayFrame};
+use crate::render::ember::EmberRenderer;
+use crate::render::spectrum::{ChannelMeta, ChannelUpload, SpectrumRenderer};
+use crate::ui::layout::CellRect;
+
+struct Check {
+    name: String,
+    pass: bool,
+    detail: String,
+}
+
+/// LF/HF crossover — reuse the same constant the real aggregator uses
+/// rather than hardcoding a second copy (I1 requires "derive... from
+/// current config, do not hardcode").
+const LF_HF_CROSSOVER_HZ: f64 = ac_core::visualize::aggregate::DEFAULT_LF_CROSSOVER_HZ as f64;
+
+/// FFT length requested for every harness capture. Fixed so the
+/// interpolation→aggregation crossover derived from the returned `freqs`
+/// grid (see `find_interp_aggregation_crossover`) is reproducible run to
+/// run; matches the size used in the original HF-garbage field capture
+/// (`tests/fixtures/fixtures-spectrum-hf-garbage/README.md`).
+const HARNESS_FFT_N: u64 = 8192;
+
+/// T2 tolerance for a single injected tone read back from the post-receiver
+/// buffer. Rationale: Hann-window scalloping loss between bin centres is
+/// ≤1.42 dB worst case (see `monitor_spectrum_wire_values_match_fake_tone`
+/// in ac-daemon's it_protocol.rs, which already carries this exact number);
+/// 1.5 dB gives a hair of margin without hiding a real multi-dB regression.
+const I1_BUFFER_TOLERANCE_DB: f64 = 1.5;
+
+/// T2 tolerance for "no value should exceed 0 dBFS" on bounded input.
+/// Rationale: broadband noise can read a few hundredths of a dB above
+/// nominal in a single bin from window-leakage constructive summation of
+/// random phase (benign); 1.0 dB is well clear of that noise floor but
+/// far below the +19 dB-class violation the HF-garbage fixture corpus
+/// demonstrates (`tests/fixtures/fixtures-spectrum-hf-garbage/README.md`).
+const I4_TOLERANCE_DB: f64 = 1.0;
+
+/// T3 pixel tolerance, in rows, for locating a trace feature at its
+/// expected position. Rationale: the issue's own risk note (architect
+/// design comment, #170) flags that lavapipe's software rasterizer can
+/// differ subtly from a real GPU at anti-aliased trace edges — assert on
+/// the trace *feature* within a small pixel band, not an exact pixel.
+const I3_PIXEL_TOLERANCE_PX: f32 = 2.0;
+
+/// Fixed offscreen render target size for every T3 check. Resolution only
+/// needs to be large enough that ±1-2 px maps to a meaningfully small dB
+/// span; matches the ember substrate's own internal resolution
+/// (`render/ember.rs::TEX_W/TEX_H`) so both views are checked at
+/// comparable pixel density.
+const T3_WIDTH: u32 = 1024;
+const T3_HEIGHT: u32 = 512;
+const T3_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+
+/// Fixed dB/freq calibration window every T3 render uses. Not read from
+/// live UI zoom/pan state (there is none here) — these are the harness's
+/// own known-good axis calibration, independent of whatever the shader
+/// actually draws, which is exactly what lets a T3 check catch an
+/// orientation or scale bug in the shader rather than agreeing with it.
+const WINDOW_DB_MIN: f32 = -90.0;
+const WINDOW_DB_MAX: f32 = 0.0;
+const WINDOW_FREQ_MIN: f32 = 20.0;
+const WINDOW_FREQ_MAX: f32 = 20_000.0;
+
+/// Entry point for `ac-ui --headless-test <ctrl_endpoint> <data_endpoint>`.
+/// Returns the same `{ok, results: [{name, pass, detail}], all_pass}` shape
+/// as `ac-daemon`'s `test_software`, so `ac-cli`'s `run_software` can print
+/// both result sets through one loop.
+pub fn run(ctrl_endpoint: &str, data_endpoint: &str) -> Value {
+    let mut checks = Vec::new();
+    match run_checked(ctrl_endpoint, data_endpoint, &mut checks) {
+        Ok(()) => {}
+        Err(e) => checks.push(Check {
+            name: "display-truth harness".to_string(),
+            pass: false,
+            detail: format!("harness error: {e}"),
+        }),
+    }
+    let all_pass = !checks.is_empty() && checks.iter().all(|c| c.pass);
+    let results: Vec<Value> = checks
+        .iter()
+        .map(|c| json!({"name": c.name, "pass": c.pass, "detail": c.detail}))
+        .collect();
+    json!({"ok": true, "results": results, "all_pass": all_pass})
+}
+
+fn run_checked(
+    ctrl_endpoint: &str,
+    data_endpoint: &str,
+    checks: &mut Vec<Check>,
+) -> anyhow::Result<()> {
+    let ctrl = CtrlClient::connect(ctrl_endpoint)?;
+    let (inputs, mut store) = ChannelStore::new(1);
+    let _receiver = receiver::spawn(
+        data_endpoint.to_string(),
+        inputs,
+        TransferStore::new(),
+        VirtualChannelStore::new(),
+        SweepStore::new(),
+        LoudnessStore::new(),
+        ScopeStore::new(),
+        None,
+    );
+    // Raw injected value, no EMA smoothing bias — I1/I4 compare against
+    // the exact value the daemon put on the wire.
+    let cfg = DisplayConfig {
+        averaging_alpha: 1.0,
+        ..Default::default()
+    };
+
+    // ── Capture 1: two tones straddling the LF/HF crossover (750 Hz) ──
+    let f_lo = LF_HF_CROSSOVER_HZ * 0.8; // ~600 Hz
+    let f_hi = LF_HF_CROSSOVER_HZ * 1.2; // ~900 Hz
+    let frame1 = capture(
+        &ctrl,
+        &mut store,
+        &cfg,
+        json!({
+            "cmd": "monitor_spectrum",
+            "channels": [0],
+            "fft_n": HARNESS_FFT_N,
+            "fake_tones": [
+                {"freq_hz": f_lo, "level_dbfs": -6.0},
+                {"freq_hz": f_hi, "level_dbfs": -18.0},
+            ],
+        }),
+        true,
+    )?;
+    check_i1_buffer(
+        checks,
+        &frame1,
+        f_lo,
+        -6.0,
+        "I1 buffer @ LF/HF-crossover low side",
+    );
+    check_i1_buffer(
+        checks,
+        &frame1,
+        f_hi,
+        -18.0,
+        "I1 buffer @ LF/HF-crossover high side",
+    );
+    check_i4_bounded(
+        checks,
+        &frame1,
+        "I4 bounded output (two-tone LF/HF capture)",
+    );
+
+    // ── T3: render capture 1 through the real Spectrum + SpectrumEmber
+    //    paint code and check pixel-level I1 apex + I3 orientation ──
+    match HeadlessGpu::new() {
+        Ok(gpu) => {
+            run_t3_checks(checks, &gpu, &frame1, f_lo, -6.0, f_hi, -18.0);
+        }
+        Err(e) => checks.push(Check {
+            name: "T3 GPU adapter".to_string(),
+            pass: false,
+            detail: format!(
+                "no wgpu adapter available ({e}) — T3 checks require a software (lavapipe) \
+                 or real Vulkan/GL adapter; see runbook, this is expected on a host with no \
+                 GPU/driver stack"
+            ),
+        }),
+    }
+
+    // ── Capture 2: two tones straddling the interpolation→aggregation
+    //    crossover, derived from capture 1's own freq grid + HARNESS_FFT_N
+    //    (not hardcoded — I1 requires deriving it from current config) ──
+    let sr = frame1.meta.sr as f64;
+    let interp_crossover =
+        find_interp_aggregation_crossover(&frame1.freqs, sr, HARNESS_FFT_N).unwrap_or(6533.0); // fallback: documented field value, only used if the grid is too coarse to detect the transition
+    let f_lo2 = interp_crossover * 0.9;
+    let f_hi2 = interp_crossover * 1.1;
+    let frame2 = capture(
+        &ctrl,
+        &mut store,
+        &cfg,
+        json!({
+            "cmd": "monitor_spectrum",
+            "channels": [0],
+            "fft_n": HARNESS_FFT_N,
+            "fake_tones": [
+                {"freq_hz": f_lo2, "level_dbfs": -6.0},
+                {"freq_hz": f_hi2, "level_dbfs": -12.0},
+            ],
+        }),
+        false,
+    )?;
+    check_i1_buffer(
+        checks,
+        &frame2,
+        f_lo2,
+        -6.0,
+        "I1 buffer @ interp/aggregation-crossover low side",
+    );
+    check_i1_buffer(
+        checks,
+        &frame2,
+        f_hi2,
+        -12.0,
+        "I1 buffer @ interp/aggregation-crossover high side",
+    );
+    check_i4_bounded(
+        checks,
+        &frame2,
+        "I4 bounded output (interp/aggregation capture)",
+    );
+
+    // ── Capture 3: calibrated broadband noise — I2 (reported, not
+    //    asserted, per Decision 2) + I4 bounded ──
+    let frame3 = capture(
+        &ctrl,
+        &mut store,
+        &cfg,
+        json!({
+            "cmd": "monitor_spectrum",
+            "channels": [0],
+            "fft_n": HARNESS_FFT_N,
+            "fake_noise_dbfs": -20.0,
+        }),
+        false,
+    )?;
+    check_i4_bounded(
+        checks,
+        &frame3,
+        "I4 bounded output (broadband noise capture)",
+    );
+    check_i2_variance_report(checks, &frame3);
+
+    let _ = ctrl.send(&json!({"cmd": "stop"}));
+    Ok(())
+}
+
+/// Send `monitor_spectrum` with `cmd_extra` merged in, then poll the
+/// receiver until a settled, non-empty frame arrives. `first` controls
+/// whether a leading `stop` is sent first (skip on the very first capture
+/// — nothing to stop yet).
+fn capture(
+    ctrl: &CtrlClient,
+    store: &mut ChannelStore,
+    cfg: &DisplayConfig,
+    cmd: Value,
+    first: bool,
+) -> anyhow::Result<DisplayFrame> {
+    if !first {
+        let _ = ctrl.send(&json!({"cmd": "stop"}));
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    let reply = ctrl.send(&cmd)?;
+    if reply.get("ok").and_then(Value::as_bool) != Some(true) {
+        anyhow::bail!("monitor_spectrum ack not ok: {reply}");
+    }
+    let deadline = Instant::now() + Duration::from_secs(8);
+    // Skip the first couple of ticks — the FFT ring may still be filling
+    // (same convention as ac-daemon's it_protocol.rs wire tests).
+    let mut seen = 0;
+    loop {
+        if Instant::now() > deadline {
+            anyhow::bail!("no usable spectrum frame within 8 s");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+        let frames = store.read_all(cfg);
+        if let Some(Some(f)) = frames.into_iter().next() {
+            if !f.spectrum.is_empty() {
+                seen += 1;
+                if seen >= 3 {
+                    return Ok(f);
+                }
+            }
+        }
+    }
+}
+
+/// Nearest-bin dBFS lookup — the harness's own independent readout, not a
+/// call into any daemon/UI aggregation code, so a bug in that aggregation
+/// can't hide from the comparison.
+fn nearest_dbfs(frame: &DisplayFrame, target_hz: f64) -> Option<(f64, f64)> {
+    let mut best: Option<(f64, f64, f64)> = None; // (freq, dbfs, |diff|)
+    for (i, &f) in frame.freqs.iter().enumerate() {
+        let diff = (f as f64 - target_hz).abs();
+        let dbfs = *frame.spectrum.get(i)? as f64;
+        if best.is_none_or(|(_, _, bd)| diff < bd) {
+            best = Some((f as f64, dbfs, diff));
+        }
+    }
+    best.map(|(f, db, _)| (f, db))
+}
+
+fn check_i1_buffer(
+    checks: &mut Vec<Check>,
+    frame: &DisplayFrame,
+    target_hz: f64,
+    level_dbfs: f64,
+    name: &str,
+) {
+    let (name, pass, detail) = match nearest_dbfs(frame, target_hz) {
+        Some((found_hz, found_db)) => {
+            let err = (found_db - level_dbfs).abs();
+            (
+                name.to_string(),
+                err <= I1_BUFFER_TOLERANCE_DB,
+                format!(
+                    "injected {level_dbfs:.1} dBFS @ {target_hz:.1} Hz, buffer column @ {found_hz:.1} \
+                     Hz = {found_db:.2} dBFS (err {err:.2} dB, tol {I1_BUFFER_TOLERANCE_DB} dB)"
+                ),
+            )
+        }
+        None => (
+            name.to_string(),
+            false,
+            format!("no buffer column found near {target_hz:.1} Hz"),
+        ),
+    };
+    checks.push(Check { name, pass, detail });
+}
+
+fn check_i4_bounded(checks: &mut Vec<Check>, frame: &DisplayFrame, name: &str) {
+    let max = frame.spectrum.iter().copied().fold(f32::MIN, f32::max) as f64;
+    let pass = max <= I4_TOLERANCE_DB;
+    checks.push(Check {
+        name: name.to_string(),
+        pass,
+        detail: format!(
+            "max buffer value = {max:.3} dBFS (bound: 0 dBFS + {I4_TOLERANCE_DB} dB tolerance)"
+        ),
+    });
+}
+
+/// I2 flat-noise continuity: per-band (LF < 750 Hz, HF ≥ 750 Hz)
+/// column-to-column variance, reported only — Decision 2 (handoff.md)
+/// defers the pass/fail threshold until LF temporal averaging lands and
+/// the equalized target is known. This check therefore always reports
+/// `pass: true`; its value is the number in `detail`, which becomes a
+/// diff once that threshold exists.
+fn check_i2_variance_report(checks: &mut Vec<Check>, frame: &DisplayFrame) {
+    let mut lf_diffs = Vec::new();
+    let mut hf_diffs = Vec::new();
+    for w in frame.freqs.windows(2).zip(frame.spectrum.windows(2)) {
+        let (fw, dw) = w;
+        let d = (dw[1] - dw[0]).abs() as f64;
+        if (fw[0] as f64) < LF_HF_CROSSOVER_HZ {
+            lf_diffs.push(d);
+        } else {
+            hf_diffs.push(d);
+        }
+    }
+    let variance = |v: &[f64]| -> f64 {
+        if v.is_empty() {
+            return 0.0;
+        }
+        let mean = v.iter().sum::<f64>() / v.len() as f64;
+        v.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / v.len() as f64
+    };
+    let lf_var = variance(&lf_diffs);
+    let hf_var = variance(&hf_diffs);
+    checks.push(Check {
+        name: "I2 flat-noise column-to-column variance (reported, not asserted)".to_string(),
+        pass: true,
+        detail: format!(
+            "LF band (<{LF_HF_CROSSOVER_HZ:.0} Hz, n={}) step variance = {lf_var:.4} dB²; \
+             HF band (n={}) step variance = {hf_var:.4} dB² — threshold deferred to LF \
+             temporal averaging (handoff.md Decision 2)",
+            lf_diffs.len(),
+            hf_diffs.len(),
+        ),
+    });
+}
+
+/// Find the column index where the aggregator's source-bin count first
+/// goes from 1 (interpolation) to ≥2 (aggregation) — i.e. where adjacent
+/// output columns stop being spaced one raw FFT bin apart. Mirrors the
+/// mechanism documented in `audit/spectrum-hf-garbage-report.md` without
+/// depending on any internal aggregator function: it only reads the
+/// `freqs` grid the daemon already put on the wire plus the requested
+/// `sr`/`fft_n`, so a bug in the aggregator's own crossover math can't
+/// mask itself from this derivation.
+fn find_interp_aggregation_crossover(freqs: &[f32], sr: f64, fft_n: u64) -> Option<f64> {
+    let bin_width = sr / fft_n as f64;
+    for w in freqs.windows(2) {
+        let spacing = (w[1] - w[0]) as f64;
+        if spacing >= bin_width * 1.5 {
+            return Some(w[0] as f64);
+        }
+    }
+    None
+}
+
+struct HeadlessGpu {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+}
+
+impl HeadlessGpu {
+    fn new() -> anyhow::Result<Self> {
+        pollster::block_on(Self::new_async())
+    }
+
+    async fn new_async() -> anyhow::Result<Self> {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY | wgpu::Backends::GL,
+            ..Default::default()
+        });
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter: false,
+            })
+            .await
+            .ok_or_else(|| anyhow::anyhow!("no wgpu adapter"))?;
+        let info = adapter.get_info();
+        log::info!(
+            "ac-ui --headless-test: wgpu backend={:?} adapter={:?} driver={:?}",
+            info.backend,
+            info.name,
+            info.driver,
+        );
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("ac-ui headless-test device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::default(),
+                    memory_hints: wgpu::MemoryHints::default(),
+                },
+                None,
+            )
+            .await?;
+        Ok(Self { device, queue })
+    }
+}
+
+fn make_offscreen_texture(device: &wgpu::Device, label: &str) -> wgpu::Texture {
+    device.create_texture(&wgpu::TextureDescriptor {
+        label: Some(label),
+        size: wgpu::Extent3d {
+            width: T3_WIDTH,
+            height: T3_HEIGHT,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: T3_FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    })
+}
+
+/// Read an offscreen texture back to unpadded, channel-order-corrected
+/// RGBA bytes. Reuses the exact same de-pad / channel-swap helpers the
+/// interactive 'S' screenshot path uses (`ui/export.rs`), so this isn't a
+/// second, possibly-diverging implementation of that bookkeeping.
+fn readback(gpu: &HeadlessGpu, tex: &wgpu::Texture, mut encoder: wgpu::CommandEncoder) -> Vec<u8> {
+    let bytes_per_row = crate::ui::export::bytes_per_row_aligned(T3_WIDTH);
+    let size = (bytes_per_row as u64) * (T3_HEIGHT as u64);
+    let buffer = gpu.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("t3 readback"),
+        size,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &buffer,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(bytes_per_row),
+                rows_per_image: Some(T3_HEIGHT),
+            },
+        },
+        wgpu::Extent3d {
+            width: T3_WIDTH,
+            height: T3_HEIGHT,
+            depth_or_array_layers: 1,
+        },
+    );
+    gpu.queue.submit(Some(encoder.finish()));
+    let slice = buffer.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |res| {
+        let _ = tx.send(res);
+    });
+    // This is where a driver crash (rather than a wgpu validation error)
+    // would surface — the CPU-side recording above is always accepted;
+    // `poll` is what actually asks the adapter to execute the command
+    // buffer. If `ac-ui --headless-test` dies with no further log output
+    // past a "rendering ... view" line, look here first.
+    let _ = gpu.device.poll(wgpu::Maintain::Wait);
+    rx.recv()
+        .expect("map_async callback channel closed")
+        .expect("map_async failed");
+    let data = slice.get_mapped_range().to_vec();
+    buffer.unmap();
+    let rgba = crate::ui::export::unpad(&data, T3_WIDTH, T3_HEIGHT, bytes_per_row);
+    crate::ui::export::channel_swap_if_needed(rgba, T3_FORMAT)
+}
+
+fn render_spectrum_pixels(gpu: &HeadlessGpu, frame: &DisplayFrame) -> Vec<u8> {
+    log::info!("t3: rendering Spectrum view offscreen");
+    let mut renderer = SpectrumRenderer::new(&gpu.device, T3_FORMAT);
+    let meta = ChannelMeta {
+        color: [1.0, 1.0, 1.0, 1.0],
+        viewport: [0.0, 0.0, 1.0, 1.0],
+        db_min: WINDOW_DB_MIN,
+        db_max: WINDOW_DB_MAX,
+        freq_log_min: WINDOW_FREQ_MIN.max(1.0).log10(),
+        freq_log_max: WINDOW_FREQ_MAX.max(WINDOW_FREQ_MIN * 1.001).log10(),
+        n_bins: 0,
+        offset: 0,
+        fill_alpha: 0.0,
+        line_width: 3.0,
+    };
+    renderer.upload(
+        &gpu.device,
+        &gpu.queue,
+        &[ChannelUpload {
+            spectrum: (*frame.spectrum).clone(),
+            meta,
+        }],
+    );
+    let tex = make_offscreen_texture(&gpu.device, "t3 spectrum");
+    let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
+    let mut encoder = gpu
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("t3 spectrum encoder"),
+        });
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("t3 spectrum pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+        renderer.draw(&mut pass);
+    }
+    readback(gpu, &tex, encoder)
+}
+
+/// Render `frame` through the real SpectrumEmber paint path
+/// (`build_ember_spectrum_trace` + `ember_pack_cell`, the exact functions
+/// `render_pipeline.rs` calls for a Single-cell SpectrumEmber view) and
+/// let the phosphor substrate settle to steady state before reading back —
+/// a single deposit at production intensity is too dim to threshold
+/// reliably (the intensity constant is tuned for multi-tick steady state,
+/// see the comment at its call site in `render_pipeline.rs`).
+fn render_ember_pixels(gpu: &HeadlessGpu, frame: &DisplayFrame) -> Vec<u8> {
+    log::info!("t3: rendering SpectrumEmber view offscreen");
+    let view = CellView {
+        freq_min: WINDOW_FREQ_MIN,
+        freq_max: WINDOW_FREQ_MAX,
+        db_min: WINDOW_DB_MIN,
+        db_max: WINDOW_DB_MAX,
+        ..Default::default()
+    };
+    let raw = build_ember_spectrum_trace(&frame.freqs, &frame.spectrum, &view, 1.0);
+    let full_cell = CellRect {
+        channel: 0,
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        h: 1.0,
+    };
+    let mut polyline = Vec::with_capacity(raw.len());
+    ember_pack_cell(&mut polyline, &raw, &full_cell, &view, 1.0);
+
+    let mut ember = EmberRenderer::new(&gpu.device, &gpu.queue, T3_FORMAT);
+    ember.set_tau_p(1.2);
+    ember.set_intensity(0.006);
+    ember.set_tone(0.6, 1.5);
+
+    let tex = make_offscreen_texture(&gpu.device, "t3 ember");
+    let view_tex = tex.create_view(&wgpu::TextureViewDescriptor::default());
+    let mut encoder = gpu
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("t3 ember encoder"),
+        });
+    // Same static polyline every tick so the substrate reaches the same
+    // steady-state luminance a continuously-running UI would settle to.
+    const TICKS: usize = 90; // ~1.5 s at 60 fps
+    for _ in 0..TICKS {
+        ember.advance(
+            &gpu.device,
+            &gpu.queue,
+            &mut encoder,
+            [0.0, 0.0, 1.0, 1.0],
+            &polyline,
+            0.0,
+            1.0 / 60.0,
+            &[],
+        );
+    }
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("t3 ember display pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &view_tex,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+        ember.draw(&mut pass);
+    }
+    readback(gpu, &tex, encoder)
+}
+
+fn freq_to_col(freq_hz: f64) -> u32 {
+    let log_min = (WINDOW_FREQ_MIN as f64).max(1.0).log10();
+    let log_max = (WINDOW_FREQ_MAX as f64)
+        .max(WINDOW_FREQ_MIN as f64 * 1.001)
+        .log10();
+    let xn = ((freq_hz.max(1.0).log10() - log_min) / (log_max - log_min).max(1e-6)).clamp(0.0, 1.0);
+    ((xn * T3_WIDTH as f64) as u32).min(T3_WIDTH - 1)
+}
+
+fn expected_row_for_db(db: f64) -> f32 {
+    let n = ((db - WINDOW_DB_MIN as f64) / (WINDOW_DB_MAX as f64 - WINDOW_DB_MIN as f64).max(1e-3))
+        .clamp(0.0, 1.0);
+    ((1.0 - n) * (T3_HEIGHT as f64 - 1.0)) as f32
+}
+
+/// Scan column `col` for the row with the greatest colour deviation from
+/// `bg` — the trace/phosphor "apex" for that column. Pure pixel-buffer
+/// analysis, independent of how the buffer was produced (GPU readback or
+/// a hand-built test fixture), which is what makes it unit-testable
+/// without a GPU below.
+fn find_trace_row(pixels: &[u8], width: u32, height: u32, col: u32, bg: [u8; 3]) -> Option<u32> {
+    let mut best_row = None;
+    let mut best_dist = 24u32; // ignore near-background noise / AA fringing
+    for row in 0..height {
+        let idx = ((row * width + col) * 4) as usize;
+        if idx + 2 >= pixels.len() {
+            continue;
+        }
+        let dist = (pixels[idx] as i32 - bg[0] as i32).unsigned_abs()
+            + (pixels[idx + 1] as i32 - bg[1] as i32).unsigned_abs()
+            + (pixels[idx + 2] as i32 - bg[2] as i32).unsigned_abs();
+        if dist > best_dist {
+            best_dist = dist;
+            best_row = Some(row);
+        }
+    }
+    best_row
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_t3_checks(
+    checks: &mut Vec<Check>,
+    gpu: &HeadlessGpu,
+    frame: &DisplayFrame,
+    f_lo: f64,
+    db_lo: f64,
+    f_hi: f64,
+    db_hi: f64,
+) {
+    let spectrum_px = render_spectrum_pixels(gpu, frame);
+    let ember_px = render_ember_pixels(gpu, frame);
+
+    for (view_name, pixels, bg) in [
+        ("Spectrum", &spectrum_px, [0u8, 0, 0]),
+        ("SpectrumEmber", &ember_px, [0u8, 0, 0]),
+    ] {
+        let col_lo = freq_to_col(f_lo);
+        let col_hi = freq_to_col(f_hi);
+        let row_lo = find_trace_row(pixels, T3_WIDTH, T3_HEIGHT, col_lo, bg);
+        let row_hi = find_trace_row(pixels, T3_WIDTH, T3_HEIGHT, col_hi, bg);
+
+        match (row_lo, row_hi) {
+            (Some(rl), Some(rh)) => {
+                // db_lo is louder than db_hi in every capture 1 uses this
+                // helper for, so its trace must land at the smaller row
+                // (higher on screen) — I3, no exemptions.
+                let pass = if db_lo > db_hi { rl < rh } else { rh < rl };
+                checks.push(Check {
+                    name: format!("I3 orientation ({view_name})"),
+                    pass,
+                    detail: format!(
+                        "{f_lo:.0} Hz @ {db_lo} dBFS -> row {rl}; {f_hi:.0} Hz @ {db_hi} dBFS -> row {rh} \
+                         (smaller row = higher on screen; louder tone must be smaller)"
+                    ),
+                });
+
+                if view_name == "Spectrum" {
+                    let exp_lo = expected_row_for_db(db_lo);
+                    let exp_hi = expected_row_for_db(db_hi);
+                    let err_lo = (rl as f32 - exp_lo).abs();
+                    let err_hi = (rh as f32 - exp_hi).abs();
+                    checks.push(Check {
+                        name: "I1 pixel apex (Spectrum)".to_string(),
+                        pass: err_lo <= I3_PIXEL_TOLERANCE_PX && err_hi <= I3_PIXEL_TOLERANCE_PX,
+                        detail: format!(
+                            "{f_lo:.0} Hz: expected row {exp_lo:.1}, found {rl} (err {err_lo:.1} px); \
+                             {f_hi:.0} Hz: expected row {exp_hi:.1}, found {rh} (err {err_hi:.1} px); \
+                             tol {I3_PIXEL_TOLERANCE_PX} px"
+                        ),
+                    });
+                }
+            }
+            _ => {
+                checks.push(Check {
+                    name: format!("I3 orientation ({view_name})"),
+                    pass: false,
+                    detail: format!(
+                        "could not locate a trace feature at one or both columns \
+                         (row_lo={row_lo:?}, row_hi={row_hi:?})"
+                    ),
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn solid_bg(width: u32, height: u32) -> Vec<u8> {
+        vec![0u8; (width * height * 4) as usize]
+    }
+
+    fn set_px(pixels: &mut [u8], width: u32, col: u32, row: u32, rgb: [u8; 3]) {
+        let idx = ((row * width + col) * 4) as usize;
+        pixels[idx] = rgb[0];
+        pixels[idx + 1] = rgb[1];
+        pixels[idx + 2] = rgb[2];
+        pixels[idx + 3] = 255;
+    }
+
+    #[test]
+    fn find_trace_row_locates_bright_pixel_against_background() {
+        let (w, h) = (16, 16);
+        let mut px = solid_bg(w, h);
+        set_px(&mut px, w, 4, 9, [255, 255, 255]);
+        let row = find_trace_row(&px, w, h, 4, [0, 0, 0]);
+        assert_eq!(row, Some(9));
+    }
+
+    #[test]
+    fn find_trace_row_none_when_column_is_all_background() {
+        let (w, h) = (16, 16);
+        let px = solid_bg(w, h);
+        assert_eq!(find_trace_row(&px, w, h, 4, [0, 0, 0]), None);
+    }
+
+    /// Harness self-test (#170 acceptance criterion): a deliberately
+    /// introduced Y-flip must be caught. This directly exercises the same
+    /// orientation logic `run_t3_checks` uses, on hand-built pixel data
+    /// standing in for a GPU readback — no adapter required.
+    #[test]
+    fn self_test_y_flip_is_caught_by_orientation_check() {
+        let (w, h) = (16, 16);
+        let col = 4;
+        let bg = [0u8, 0, 0];
+
+        // Correct orientation: louder (db_lo=-6) trace at smaller row than
+        // quieter (db_hi=-18) trace.
+        let mut correct = solid_bg(w, h);
+        set_px(&mut correct, w, col, 3, [255, 255, 255]); // louder -> near top
+        let row_louder = find_trace_row(&correct, w, h, col, bg).unwrap();
+        assert!(
+            row_louder < h / 2,
+            "sanity: louder trace should be in upper half"
+        );
+
+        // Deliberately flipped: same data, mirrored vertically — this is
+        // exactly the class of bug I3/T3 exists to catch (the ember Y
+        // inversion, #170 handoff.md).
+        let mut flipped = solid_bg(w, h);
+        set_px(&mut flipped, w, col, h - 1 - 3, [255, 255, 255]);
+        let row_flipped = find_trace_row(&flipped, w, h, col, bg).unwrap();
+
+        let pass_correct = row_louder < h / 2;
+        let pass_flipped = row_flipped < h / 2;
+        assert!(
+            pass_correct,
+            "correct orientation must pass the 'louder = higher' check"
+        );
+        assert!(
+            !pass_flipped,
+            "flipped orientation must fail the 'louder = higher' check"
+        );
+    }
+
+    /// Harness self-test (#170 acceptance criterion): a deliberately
+    /// introduced +6 dB offset must be caught at T2 (buffer). Fabricates a
+    /// `DisplayFrame` with a known error and confirms `check_i1_buffer`
+    /// flags it — no daemon required.
+    #[test]
+    fn self_test_plus_6db_offset_is_caught_at_t2() {
+        use crate::data::types::FrameMeta;
+        use std::sync::Arc;
+
+        let frame = DisplayFrame {
+            freqs: Arc::new(vec![1000.0]),
+            // Injected level was -20 dBFS; buffer reports -14 dBFS — a +6
+            // dB offset bug (the class handoff.md cites: aggregate.rs
+            // double-dB-conversion).
+            spectrum: Arc::new(vec![-14.0]),
+            meta: FrameMeta {
+                freq_hz: 1000.0,
+                fundamental_dbfs: -14.0,
+                thd_pct: 0.0,
+                thdn_pct: 0.0,
+                in_dbu: None,
+                dbu_offset_db: None,
+                peaks: Arc::new(Vec::new()),
+                spl_offset_db: None,
+                mic_correction: None,
+                sr: 48_000,
+                clipping: false,
+                xruns: 0,
+                leq_duration_s: None,
+            },
+            new_row: None,
+        };
+        let mut checks = Vec::new();
+        check_i1_buffer(&mut checks, &frame, 1000.0, -20.0, "self-test +6dB");
+        assert_eq!(checks.len(), 1);
+        assert!(
+            !checks[0].pass,
+            "a +6 dB offset ({:.1} dB error) must fail I1's {I1_BUFFER_TOLERANCE_DB} dB tolerance: {}",
+            6.0,
+            checks[0].detail,
+        );
+    }
+
+    #[test]
+    fn nearest_dbfs_picks_closest_bin() {
+        use crate::data::types::FrameMeta;
+        use std::sync::Arc;
+        let frame = DisplayFrame {
+            freqs: Arc::new(vec![100.0, 500.0, 1000.0, 2000.0]),
+            spectrum: Arc::new(vec![-40.0, -30.0, -20.0, -10.0]),
+            meta: FrameMeta {
+                freq_hz: 1000.0,
+                fundamental_dbfs: -20.0,
+                thd_pct: 0.0,
+                thdn_pct: 0.0,
+                in_dbu: None,
+                dbu_offset_db: None,
+                peaks: Arc::new(Vec::new()),
+                spl_offset_db: None,
+                mic_correction: None,
+                sr: 48_000,
+                clipping: false,
+                xruns: 0,
+                leq_duration_s: None,
+            },
+            new_row: None,
+        };
+        let (f, db) = nearest_dbfs(&frame, 950.0).unwrap();
+        assert_eq!(f, 1000.0);
+        assert_eq!(db, -20.0);
+    }
+
+    #[test]
+    fn find_interp_aggregation_crossover_detects_spacing_jump() {
+        // Synthetic grid: one-bin-wide spacing (0.5 Hz) up to col 100, then
+        // a jump to 5x spacing — the aggregation branch's signature.
+        let bin_width = 0.5_f64;
+        let mut freqs = Vec::new();
+        for i in 0..100 {
+            freqs.push((i as f64 * bin_width) as f32);
+        }
+        let last = freqs.last().copied().unwrap() as f64;
+        for i in 0..20 {
+            freqs.push((last + i as f64 * bin_width * 5.0) as f32);
+        }
+        let sr = bin_width * 8192.0; // so sr/fft_n == bin_width
+        let crossover = find_interp_aggregation_crossover(&freqs, sr, 8192).unwrap();
+        assert!((crossover as f32 - freqs[99]).abs() < 0.01);
+    }
+
+    /// I4 must-fail regression corpus (#170 handoff.md / Decision 3
+    /// validation gate): `ac monitor`'s own CSV export format, parsed with
+    /// no daemon or GPU involved, must trip the same bounded-output check
+    /// `check_i4_bounded` uses on a live capture. These five fixtures are
+    /// the documented aggregate.rs double-dB-conversion bug's field
+    /// signature (`tests/fixtures/fixtures-spectrum-hf-garbage/README.md`)
+    /// — 876 violations per file above ~6533 Hz, up to +19.115 dBFS.
+    #[test]
+    fn i4_fixture_corpus_known_bad_csvs_fail_bounded_output() {
+        // CARGO_MANIFEST_DIR = .../ac-rs/crates/ac-ui; fixtures live at the
+        // outer repo root's tests/ (a sibling of ac-rs/, not inside it —
+        // see ../../CLAUDE.md's "Repo structure").
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../tests/fixtures/fixtures-spectrum-hf-garbage");
+        let mut checked = 0;
+        for entry in std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("could not read fixture dir {}: {e}", dir.display()))
+        {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|e| e.to_str()) != Some("csv") {
+                continue;
+            }
+            let body = std::fs::read_to_string(&path).unwrap();
+            let max = max_dbfs_in_csv(&body);
+            assert!(
+                max > 0.0,
+                "{}: expected a known-bad fixture (max > 0 dBFS), got max={max:.3} — \
+                 if the underlying bug is now fixed, this fixture should move to a \
+                 known-good reference set instead of silently passing here",
+                path.display(),
+            );
+            checked += 1;
+        }
+        assert_eq!(
+            checked,
+            5,
+            "expected exactly 5 known-bad fixtures in {}",
+            dir.display()
+        );
+    }
+
+    /// Minimal reader for the `ac monitor` CSV export shape (`# `-prefixed
+    /// metadata, then `freq_hz,ch0_dbfs,ch0_mic_corrected,...`). Only
+    /// extracts the max dBFS across every `*_dbfs` column — enough for the
+    /// I4 bounded-output check, not a general-purpose CSV reader.
+    fn max_dbfs_in_csv(body: &str) -> f64 {
+        let mut lines = body.lines().filter(|l| !l.starts_with('#'));
+        let header = lines.next().unwrap_or("");
+        let dbfs_cols: Vec<usize> = header
+            .split(',')
+            .enumerate()
+            .filter(|(_, name)| name.ends_with("_dbfs"))
+            .map(|(i, _)| i)
+            .collect();
+        let mut max = f64::MIN;
+        for line in lines {
+            let cols: Vec<&str> = line.split(',').collect();
+            for &i in &dbfs_cols {
+                if let Some(v) = cols.get(i).and_then(|s| s.parse::<f64>().ok()) {
+                    max = max.max(v);
+                }
+            }
+        }
+        max
+    }
+}

--- a/ac-rs/crates/ac-ui/src/main.rs
+++ b/ac-rs/crates/ac-ui/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod data;
+mod headless;
 mod render;
 mod theme;
 mod ui;
@@ -22,6 +23,19 @@ fn main() -> anyhow::Result<()> {
     if args.help {
         print_help();
         return Ok(());
+    }
+
+    // Display-truth harness (#170, `ac test software`): run T2/T3 checks
+    // against whatever daemon `--ctrl`/`--connect` point at and exit —
+    // never opens a window, never touches JACK/CPAL, no winit event loop.
+    if args.headless_test {
+        let result = headless::run(&args.ctrl, &args.connect);
+        println!("{}", serde_json::to_string(&result)?);
+        let all_pass = result
+            .get("all_pass")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        std::process::exit(if all_pass { 0 } else { 1 });
     }
 
     let (monitor_channels, n_channels) = if let Some(ref chs) = args.channels {
@@ -141,6 +155,9 @@ struct Args {
     /// for smoother motion. On stacks where `present()` is expensive
     /// (NVIDIA + Vulkan + X11) leave at 30 or drop further.
     continuous_interval: Duration,
+    /// `--headless-test` — run the T2/T3 display-truth harness (#170)
+    /// against `--ctrl`/`--connect` and exit; no window, no winit loop.
+    headless_test: bool,
 }
 
 fn parse_max_fps(s: &str) -> anyhow::Result<Duration> {
@@ -219,6 +236,7 @@ impl Args {
             mode: None,
             present_mode: env_present_mode,
             continuous_interval: env_continuous_interval,
+            headless_test: false,
         };
         let mut it = args.peekable();
         while let Some(arg) = it.next() {
@@ -268,6 +286,9 @@ impl Args {
                 }
                 "--no-persist" => {
                     out.no_persist = true;
+                }
+                "--headless-test" => {
+                    out.headless_test = true;
                 }
                 "--view" => {
                     let v = it
@@ -350,6 +371,8 @@ Options:\n  \
   --output-dir <path>  Screenshot/CSV dir [default: ~/ac-screenshots]\n  \
   --benchmark <secs>   Run for N seconds, print timing summary, exit\n  \
   --no-persist         Don't read/write ~/.config/ac/ui.json this session\n  \
+  --headless-test      Run T2/T3 display-truth checks against --ctrl/--connect, print JSON, exit\n  \
+                       (#170; no window, no winit loop — driven by `ac test software`)\n  \
   --view <mode>        Initial view: spectrum|waterfall|scope|spectrum_ember|goniometer [default: spectrum]\n  \
   --mode <mode>        Start in sweep mode: sweep_frequency|sweep_level\n  \
   --present-mode <m>   wgpu present mode: auto-vsync|auto-no-vsync|fifo|fifo-relaxed|mailbox|immediate\n  \

--- a/ac-rs/crates/ac-ui/src/ui/export.rs
+++ b/ac-rs/crates/ac-ui/src/ui/export.rs
@@ -49,7 +49,9 @@ fn save(req: ScreenshotRequest) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn unpad(padded: &[u8], width: u32, height: u32, bytes_per_row: u32) -> Vec<u8> {
+/// `pub(crate)`: reused by the headless display-truth harness (#170) to
+/// de-pad a wgpu texture readback the same way a screenshot does.
+pub(crate) fn unpad(padded: &[u8], width: u32, height: u32, bytes_per_row: u32) -> Vec<u8> {
     let row_bytes = (width * 4) as usize;
     let mut out = Vec::with_capacity(row_bytes * height as usize);
     for y in 0..height as usize {
@@ -59,7 +61,8 @@ fn unpad(padded: &[u8], width: u32, height: u32, bytes_per_row: u32) -> Vec<u8> 
     out
 }
 
-fn channel_swap_if_needed(mut rgba: Vec<u8>, format: wgpu::TextureFormat) -> Vec<u8> {
+/// `pub(crate)`: see `unpad` above.
+pub(crate) fn channel_swap_if_needed(mut rgba: Vec<u8>, format: wgpu::TextureFormat) -> Vec<u8> {
     if matches!(
         format,
         wgpu::TextureFormat::Bgra8Unorm | wgpu::TextureFormat::Bgra8UnormSrgb

--- a/ac-rs/crates/ac-ui/tests/it_display_truth.rs
+++ b/ac-rs/crates/ac-ui/tests/it_display_truth.rs
@@ -1,0 +1,204 @@
+//! Display-truth harness (T2/T3) end-to-end — #170.
+//!
+//! Spawns a real, isolated `ac-daemon --fake-audio` + `ac-ui
+//! --headless-test` pair (same subprocess-spawn idiom as
+//! `it_views_smoke.rs`) and asserts against the actual JSON the harness
+//! produces. `#[ignore]`'d by default — needs a wgpu adapter (software
+//! Vulkan/lavapipe or a real GPU); runbook only:
+//!
+//!   cargo test -p ac-ui --test it_display_truth -- --include-ignored
+//!
+//! This is the CI-equivalent gate `ac-cli`'s `run_software` (`ac test
+//! software`) wraps for human use; this test drives the same two binaries
+//! directly so a harness regression fails fast without going through the
+//! CLI's table-printing layer.
+
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+const AC_UI: &str = env!("CARGO_BIN_EXE_ac-ui");
+
+/// `ac-daemon` has no library target, so Cargo can't add it as an
+/// `ac-ui` dev-dependency to populate `CARGO_BIN_EXE_ac-daemon` the way
+/// `it_protocol.rs` does from inside ac-daemon's own package. Instead,
+/// resolve it as a sibling of this test binary's own `ac-ui` executable —
+/// both land in the same `target/<profile>/` directory in this workspace.
+/// Requires `ac-daemon` to have been built already (`cargo build -p
+/// ac-daemon` or a full workspace build) before running this
+/// `--include-ignored` runbook test.
+fn ac_daemon_bin() -> std::path::PathBuf {
+    let p = std::path::Path::new(AC_UI).with_file_name("ac-daemon");
+    assert!(
+        p.exists(),
+        "ac-daemon binary not found at {} — build it first: cargo build -p ac-daemon",
+        p.display()
+    );
+    p
+}
+
+fn free_port_pair() -> (u16, u16) {
+    let a = TcpListener::bind("127.0.0.1:0").unwrap();
+    let b = TcpListener::bind("127.0.0.1:0").unwrap();
+    (
+        a.local_addr().unwrap().port(),
+        b.local_addr().unwrap().port(),
+    )
+}
+
+struct Daemon {
+    child: Child,
+}
+
+impl Daemon {
+    fn spawn(ctrl_port: u16, data_port: u16) -> Self {
+        let child = Command::new(ac_daemon_bin())
+            .args([
+                "--local",
+                "--fake-audio",
+                "--ctrl-port",
+                &ctrl_port.to_string(),
+                "--data-port",
+                &data_port.to_string(),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn ac-daemon");
+        let ctx = zmq::Context::new();
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            if Instant::now() > deadline {
+                panic!("ac-daemon never came up on ctrl port {ctrl_port}");
+            }
+            std::thread::sleep(Duration::from_millis(50));
+            let s = ctx.socket(zmq::REQ).unwrap();
+            s.set_linger(0).ok();
+            s.set_rcvtimeo(300).ok();
+            s.set_sndtimeo(300).ok();
+            if s.connect(&format!("tcp://127.0.0.1:{ctrl_port}")).is_err() {
+                continue;
+            }
+            if s.send(r#"{"cmd":"status"}"#, 0).is_err() {
+                continue;
+            }
+            if let Ok(Ok(reply)) = s.recv_string(0) {
+                if let Ok(v) = serde_json::from_str::<Value>(&reply) {
+                    if v.get("ok").and_then(Value::as_bool) == Some(true) {
+                        break;
+                    }
+                }
+            }
+        }
+        Self { child }
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Run `ac-ui --headless-test` against `daemon` and return its parsed JSON
+/// result. Panics (rather than silently treating a crash as "no results")
+/// if the process didn't exit cleanly with JSON on stdout — this test's
+/// entire job is to notice that.
+fn run_headless_test(ctrl_port: u16, data_port: u16) -> Value {
+    let output = Command::new(AC_UI)
+        .args([
+            "--headless-test",
+            "--ctrl",
+            &format!("tcp://127.0.0.1:{ctrl_port}"),
+            "--connect",
+            &format!("tcp://127.0.0.1:{data_port}"),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn ac-ui --headless-test");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "ac-ui --headless-test did not produce parseable JSON \
+             (status={:?}): {e}\nstdout: {stdout}\nstderr tail: {}",
+            output.status.code(),
+            stderr.lines().rev().take(40).collect::<Vec<_>>().join("\n"),
+        )
+    })
+}
+
+fn find_check<'a>(results: &'a [Value], name_substr: &str) -> Option<&'a Value> {
+    results.iter().find(|r| {
+        r.get("name")
+            .and_then(Value::as_str)
+            .is_some_and(|n| n.contains(name_substr))
+    })
+}
+
+#[test]
+#[ignore = "spawns ac-daemon + ac-ui; needs a wgpu adapter — runbook only (#170)"]
+fn display_truth_harness_runs_and_reports_i1_i4() {
+    let (ctrl_port, data_port) = free_port_pair();
+    let _daemon = Daemon::spawn(ctrl_port, data_port);
+    let result = run_headless_test(ctrl_port, data_port);
+
+    let results = result
+        .get("results")
+        .and_then(Value::as_array)
+        .expect("results array");
+    assert!(
+        !results.is_empty(),
+        "expected at least one check, got none: {result}"
+    );
+
+    // I1: buffer-level tone accuracy at the LF/HF crossover must pass on
+    // current main (no known-open bug affects it).
+    let i1 = find_check(results, "I1 buffer @ LF/HF-crossover low side")
+        .unwrap_or_else(|| panic!("missing I1 LF/HF check in {results:?}"));
+    assert_eq!(
+        i1.get("pass").and_then(Value::as_bool),
+        Some(true),
+        "I1 buffer check should pass on current main: {i1}"
+    );
+
+    // I4: bounded output must pass on current main for a two-tone fake
+    // capture (the known-open HF-garbage bug is exercised separately by
+    // the fixture corpus in headless.rs's unit tests, not by a live
+    // capture at these frequencies).
+    let i4 = find_check(results, "I4 bounded output (two-tone LF/HF capture)")
+        .unwrap_or_else(|| panic!("missing I4 check in {results:?}"));
+    assert_eq!(
+        i4.get("pass").and_then(Value::as_bool),
+        Some(true),
+        "I4 bounded-output check should pass on current main: {i4}"
+    );
+}
+
+/// Acceptance criterion (#170 handoff.md): "ember flip fails I3" must be
+/// demonstrated as a currently-failing test, not silently absent. If this
+/// assertion starts failing, the ember Y-inversion bug has been fixed —
+/// flip it to `assert_eq!(..., Some(true), ...)` and close out the
+/// tracking reference in `handoff-ember-yflip.md`.
+#[test]
+#[ignore = "spawns ac-daemon + ac-ui; needs a wgpu adapter — runbook only (#170)"]
+fn known_open_bug_ember_orientation_currently_fails_i3() {
+    let (ctrl_port, data_port) = free_port_pair();
+    let _daemon = Daemon::spawn(ctrl_port, data_port);
+    let result = run_headless_test(ctrl_port, data_port);
+    let results = result
+        .get("results")
+        .and_then(Value::as_array)
+        .expect("results array");
+    let ember_i3 = find_check(results, "I3 orientation (SpectrumEmber)")
+        .unwrap_or_else(|| panic!("missing SpectrumEmber I3 check in {results:?}"));
+    assert_ne!(
+        ember_i3.get("pass").and_then(Value::as_bool),
+        Some(true),
+        "ember Y-inversion appears fixed ({ember_i3}) — see the doc comment on this test"
+    );
+}


### PR DESCRIPTION
closes #170

### what changed
Extends `ac test software` with the T2/T3 display-truth harness the issue specs: a new `ac-ui --headless-test` mode connects to a daemon endpoint with no window/winit loop, runs T2 checks straight off the post-receiver `DisplayFrame` buffer, then renders the same frame through the *real* production `SpectrumRenderer` / `EmberRenderer` (+ `build_ember_spectrum_trace`/`ember_pack_cell`, promoted to `pub(crate)` and reused verbatim, not reimplemented) to an offscreen wgpu texture and checks pixel-level I1 apex + I3 orientation. `ac-cli`'s `run_software` spawns an *isolated* `ac-daemon --fake-audio` + `ac-ui --headless-test` pair on OS-assigned ports (never the caller's own daemon, which may be real hardware) and merges results into one table, exiting nonzero on any failure.

To drive the stimuli I1/I3 need, `ac-daemon`'s fake backend gained real multi-tone (`set_tone_pair`) and broadband-noise (`set_broadband_noise`) synthesis (previously `set_pink` just faked a sine), wired through new optional `fake_tones`/`fake_noise_dbfs`/`amplitude` fields on `monitor_spectrum`, gated to `--fake-audio` only.

**Known limitation, needs verification on a real dev/CI box:** in this sandbox, `ac-ui --headless-test`'s T3 step segfaults inside the Vulkan/lavapipe driver itself during `device.poll()` after recording `SpectrumRenderer::draw()` — confirmed via a minimal standalone wgpu repro that basic offscreen clear+readback works fine here, so it's specific to that draw call's storage-buffer-in-vertex-shader pattern under this sandbox's Mesa/llvmpipe build, not a logic bug in the harness. The orchestration handles this gracefully end-to-end (verified live): `ac test software` detects the crash, reports a clear FAIL row instead of hanging or false-passing, and still exits nonzero. T2 (all buffer-level I1/I4/I2 checks) is fully implemented, unit-tested, and verified working end-to-end over real ZMQ against a live fake-audio daemon. See "open questions" below.

### files touched
- `ac-rs/crates/ac-daemon/src/audio/mod.rs` — `AudioEngine::set_tone_pair`/`set_broadband_noise`, default no-op on real backends
- `ac-rs/crates/ac-daemon/src/audio/fake.rs` — real multi-tone/noise synthesis (`Stimulus` enum replaces the old single freq/amp fields); existing single-tone behavior preserved byte-for-byte (verified: all pre-existing tests still pass)
- `ac-rs/crates/ac-daemon/src/handlers/audio/monitor.rs` — wires the previously-dead `freq_hz` param plus new `amplitude`/`fake_tones`/`fake_noise_dbfs`, applied only when `state.fake_audio`
- `ac-rs/crates/ac-daemon/tests/it_protocol.rs` — two new wire-level tests for the stimulus knobs
- `ac-rs/crates/ac-ui/src/headless.rs` (new) — the T2/T3 checker + offscreen GPU harness; pixel-analysis logic is pure/GPU-free and unit-tested directly, including two explicit self-tests (deliberate Y-flip, deliberate +6 dB offset) per the issue's harness-self-test acceptance criterion, plus the I4 must-fail fixture-corpus regression against the 5 known-bad CSVs in `tests/fixtures/fixtures-spectrum-hf-garbage/`
- `ac-rs/crates/ac-ui/src/main.rs` — `--headless-test` flag
- `ac-rs/crates/ac-ui/src/app/render_pipeline.rs` — `build_ember_spectrum_trace`/`ember_pack_cell` promoted to `pub(crate)` (no behavior change) so the harness reuses the exact production ember paint path
- `ac-rs/crates/ac-ui/src/ui/export.rs` — `unpad`/`channel_swap_if_needed` promoted to `pub(crate)` for T3 readback reuse
- `ac-rs/crates/ac-ui/tests/it_display_truth.rs` (new) — end-to-end integration test, `#[ignore]`'d like `it_views_smoke.rs` (needs a wgpu adapter, runbook only); includes the required "ember flip fails I3" red test
- `.agents/qa.md` — runbook line: value-display PRs need harness green before `qa-approved`

### test output
```
699 passed, 0 failed, 3 ignored (workspace-wide `cargo test`)
  ac-cli: 82   ac-core: 280   ac-daemon: 65+4+1ignored+49   ac-ui: 219+2ignored+2ignored
cargo clippy -- -D warnings: clean
cargo fmt --check: clean
```
Live-verified `ac test software` end-to-end against a real spawned fake-audio daemon: daemon self-test 10/10 PASS, harness correctly detects and reports the T3 crash, overall exit code 1.

### ZMQ schema changed
No — `monitor_spectrum` gained optional fields only (`amplitude`, `fake_tones`, `fake_noise_dbfs`), all backward compatible, all no-ops on real hardware.

### new dependencies
None (all reused existing workspace deps: `wgpu`, `pollster`, `zmq`, already present in `ac-ui`/`ac-cli`).

### related
None opened — the T3 driver crash is environment-specific to this sandbox, not a code defect I could isolate to a specific file/line to file separately; see open questions.

### open questions for reviewer
1. **T3 needs validation on a real dev/CI box.** Per the issue's own Decision 3 validation gate, T3 is only "accepted as the pixel-truth layer" once it demonstrably catches the two currently-open bugs under lavapipe. I could not complete that validation here (driver segfault, not a logic issue — see above). Please run `cargo test -p ac-ui --test it_display_truth -- --include-ignored` on a machine with a working lavapipe/GPU and confirm `known_open_bug_ember_orientation_currently_fails_i3` actually fails red (proving T3 catches the ember flip) before treating T3 as load-bearing for the `qa-approved` gate I added to `.agents/qa.md`.
2. **T3 view coverage is Spectrum + SpectrumEmber only**, not Waterfall/Scope. Given time constraints I prioritized the two views the issue explicitly calls out (ember flip is the canonical T3 target); extending pixel checks to Waterfall/Scope is straightforward with the same `find_trace_row` machinery but is follow-up work, not opened as a separate tracked issue since it's clearly an extension of this same harness rather than an independent bug.
3. **I2 variance threshold** is reported-only per Decision 2, as specced — no action needed until LF temporal averaging lands.
4. `.agents/qa.md` is otherwise stale relative to this codebase (references `ac::estimator`, `thd_tool`, `ds`, which don't exist in `ac-rs/`) — I added one bullet without touching the rest; flagging in case that mismatch is worth its own cleanup pass.