### PR TITLE
fix: SpectrumEmber Y-axis inversion in display shader

### DIFF
--- a/ac-rs/crates/ac-ui/src/render/shaders/ember_display.wgsl
+++ b/ac-rs/crates/ac-ui/src/render/shaders/ember_display.wgsl
@@ -36,7 +36,12 @@ fn vs_main(@builtin(vertex_index) vid: u32) -> VsOut {
 @fragment
 fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     let dims = textureDimensions(src);
-    let coord = vec2<i32>(in.uv * vec2<f32>(dims));
+    // Deposit writes via NDC (y=1 -> top texel row); the display viewport's
+    // uv.y also runs screen-bottom(0)->top(1) with no inherent row flip, so
+    // sampling `uv` directly reads the substrate mirrored top-to-bottom
+    // (the ember Y-inversion bug, #172). Flip here, matching the row lookup
+    // waterfall.wgsl already does for the same deposit/read asymmetry.
+    let coord = vec2<i32>(vec2<f32>(in.uv.x, 1.0 - in.uv.y) * vec2<f32>(dims));
     let l = textureLoad(src, coord, 0).r;
     let scaled = max(l * params.gain, 0.0);
     let t = clamp(pow(scaled, params.gamma), 0.0, 1.0);

--- a/ac-rs/crates/ac-ui/tests/it_display_truth.rs
+++ b/ac-rs/crates/ac-ui/tests/it_display_truth.rs
@@ -179,14 +179,15 @@ fn display_truth_harness_runs_and_reports_i1_i4() {
     );
 }
 
-/// Acceptance criterion (#170 handoff.md): "ember flip fails I3" must be
-/// demonstrated as a currently-failing test, not silently absent. If this
-/// assertion starts failing, the ember Y-inversion bug has been fixed —
-/// flip it to `assert_eq!(..., Some(true), ...)` and close out the
-/// tracking reference in `handoff-ember-yflip.md`.
+/// Ember Y-axis orientation, permanent I3 assertion (#172). Was tracked as
+/// `known_open_bug_ember_orientation_currently_fails_i3` while the bug was
+/// open (`ember_display.wgsl` sampled the substrate texture without the
+/// screen/deposit row flip `waterfall.wgsl` already applies, so the louder
+/// tone rendered lower on screen instead of higher). Converted to a normal
+/// pass assertion now that the flip is in place.
 #[test]
 #[ignore = "spawns ac-daemon + ac-ui; needs a wgpu adapter — runbook only (#170)"]
-fn known_open_bug_ember_orientation_currently_fails_i3() {
+fn ember_orientation_passes_i3() {
     let (ctrl_port, data_port) = free_port_pair();
     let _daemon = Daemon::spawn(ctrl_port, data_port);
     let result = run_headless_test(ctrl_port, data_port);
@@ -196,9 +197,9 @@ fn known_open_bug_ember_orientation_currently_fails_i3() {
         .expect("results array");
     let ember_i3 = find_check(results, "I3 orientation (SpectrumEmber)")
         .unwrap_or_else(|| panic!("missing SpectrumEmber I3 check in {results:?}"));
-    assert_ne!(
+    assert_eq!(
         ember_i3.get("pass").and_then(Value::as_bool),
         Some(true),
-        "ember Y-inversion appears fixed ({ember_i3}) — see the doc comment on this test"
+        "ember I3 orientation should pass post-fix: {ember_i3}"
     );
 }


### PR DESCRIPTION
closes #172

### what changed
`ember_deposit.wgsl` writes each vertex's `xy.y` straight to NDC (`y=1` lands on the top texel row of the substrate texture). `ember_display.wgsl`'s fragment shader then sampled that texture with the viewport's raw `uv` (also bottom(0)→top(1)) with no row flip in between — `waterfall.wgsl` already flips (`1.0 - uv.y`) before its row lookup for the exact same deposit/read asymmetry, ember never did. Net effect: louder content, deposited near the top texel row, read back at the bottom of the screen — a vertical mirror. Fix is the one-line flip in `ember_display.wgsl`'s `fs_main`, matching the working pattern in `waterfall.wgsl`. No changes to `ember_deposit.wgsl`, the CPU trace-building path (`build_ember_spectrum_trace`/`ember_pack_cell`), or any data/wire/readout code — this is a render-path-only fix per the issue's scope.

Also converts the harness's guard test from `known_open_bug_ember_orientation_currently_fails_i3` (asserted not-pass) to `ember_orientation_passes_i3` (asserts pass), per the acceptance criterion and the test's own doc comment instructing that flip once fixed.

### files touched
- `ac-ui/src/render/shaders/ember_display.wgsl` — flip `uv.y` before texture row lookup in `fs_main`
- `ac-ui/tests/it_display_truth.rs` — guard test converted to permanent I3 pass assertion

### test output
```
cargo test: 219 passed; 0 failed; 0 ignored (unit + lib tests)
it_display_truth.rs: 2 ignored (runbook-only, needs wgpu adapter)
cargo clippy -- -D warnings: clean
cargo fmt --check: clean
```

**Could not run the T3 pixel checks in this sandbox** — `cargo test -p ac-ui --test it_display_truth -- --include-ignored` crashes here under llvmpipe/Vulkan (`ac-ui --headless-test did not produce parseable JSON`), the same known sandbox limitation PR #171 documented (T3's `device.poll()` after `SpectrumRenderer::draw()` misbehaves under this box's Mesa/llvmpipe build — not specific to this change, `display_truth_harness_runs_and_reports_i1_i4` fails identically on unmodified `main` in this same sandbox). Verified the fix by tracing the NDC/UV math through both shaders against the working `waterfall.wgsl` reference instead. Per the issue's own acceptance criteria, this needs to run on a verified adapter (RADV dev box) per the harness runbook before merge:
```
cargo build -p ac-daemon
cargo test -p ac-ui --test it_display_truth -- --include-ignored
```

### ZMQ schema changed
no

### new dependencies
none

### related
none

### open questions for reviewer
T3 verification on a real GPU (RADV box) is still outstanding — I could only verify this by reasoning through the shader math and comparing to `waterfall.wgsl`'s established pattern, not by observing the harness flip red→green myself. Please run the runbook command above before merging.