### PR TITLE
fix: overlap + power-domain EMA on LF spectrum band

### DIFF
--- a/ac-rs/crates/ac-core/src/visualize/time_integration.rs
+++ b/ac-rs/crates/ac-core/src/visualize/time_integration.rs
@@ -339,6 +339,107 @@ mod tests {
         assert!(approx(leq.current()[0], -40.0, 1e-9));
     }
 
+    // ---- LF temporal-averaging tuning (#173) ----
+    //
+    // The un-overlapped LF FFT path emits one raw periodogram per block
+    // (~0.7-1.4 s); each bin under broadband material is chi-squared(2)
+    // distributed (`p_bin = p_true * X`, `X ~ Exp(1)`), giving `Var(ln X) =
+    // pi^2/6` and thus `sigma_dB = (10/ln 10) * sqrt(pi^2/6) ~= 5.57 dB` per
+    // recompute — matching issue #173's measured 5.5-9.4 dB RMS and its own
+    // "~5.6 dB sigma" framing. These tests confirm `EmaIntegrator` (already
+    // proven per-band for fast/slow/Leq) generalizes cleanly to a large,
+    // per-bin-style state vector and picks a time constant that brings that
+    // 5.57 dB raw sigma within 2x of the HF band's measured 0.7-2.4 dB.
+
+    /// Deterministic xorshift64* PRNG — no new crate dependency for a
+    /// reproducible test-only noise source.
+    struct XorShift64(u64);
+    impl XorShift64 {
+        fn next_u64(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x.wrapping_mul(0x2545_f4914f_6cdd1d)
+        }
+        /// One chi-squared(2)/2 draw, i.e. `X ~ Exp(1)`, via inverse-CDF.
+        fn next_exp1(&mut self) -> f64 {
+            let u = (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64;
+            -(1.0 - u).ln().max(-745.0) // avoid ln(0) on the (unreachable) u=1 edge
+        }
+    }
+
+    /// Sample stddev of a slice.
+    fn stddev(xs: &[f64]) -> f64 {
+        let n = xs.len() as f64;
+        let mean = xs.iter().sum::<f64>() / n;
+        (xs.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n).sqrt()
+    }
+
+    #[test]
+    fn raw_chi_squared_periodogram_matches_issue_5_6_db_sigma() {
+        let mut rng = XorShift64(0xC0FF_EE00_1234_5678);
+        let samples_db: Vec<f64> = (0..20_000)
+            .map(|_| 10.0 * rng.next_exp1().log10())
+            .collect();
+        let sigma = stddev(&samples_db);
+        // Issue #173 cites ~5.6 dB sigma for un-averaged chi-squared(2) bin
+        // statistics on broadband material; confirm the model reproduces it.
+        assert!(
+            (sigma - 5.57).abs() < 0.15,
+            "expected ~5.57 dB sigma (chi-squared(2) model), got {sigma:.3}"
+        );
+    }
+
+    #[test]
+    fn lf_ema_brings_variance_within_2x_of_hf_target() {
+        // Chosen constants (mirrored as LF_OVERLAP / LF_AVG_TAU_S in
+        // ac-daemon's monitor.rs): 90% overlap on a 65536-pt/48kHz LF FFT
+        // gives a ~136.5 ms recompute hop; tau = 0.25 s.
+        let hop_s = 0.1365;
+        let tau_s = 0.25;
+        let hf_reference_sigma_db = 1.5; // mid-point of issue's measured 0.7-2.4 dB HF range
+
+        let mut rng = XorShift64(0xC0FF_EE00_1234_5678);
+        let mut ema = EmaIntegrator::new(tau_s, 1);
+        let mut smoothed_db = Vec::with_capacity(2_000);
+        for _ in 0..2_000 {
+            let raw_db = 10.0 * rng.next_exp1().log10();
+            smoothed_db.push(ema.update(&[raw_db], hop_s)[0]);
+        }
+        // Drop the initial transient (first ~5 tau) before measuring
+        // steady-state variance.
+        let settle_frames = ((5.0 * tau_s / hop_s).ceil() as usize).min(smoothed_db.len() / 2);
+        let sigma = stddev(&smoothed_db[settle_frames..]);
+
+        assert!(
+            sigma <= 2.0 * hf_reference_sigma_db,
+            "post-EMA LF sigma {sigma:.3} dB exceeds 2x HF reference ({:.3} dB)",
+            2.0 * hf_reference_sigma_db
+        );
+    }
+
+    #[test]
+    fn ema_generalizes_to_lf_bin_count_without_bias() {
+        // LF path has 32769 bins (65536/2+1) — confirm EmaIntegrator (so
+        // far only exercised at octave-band counts) holds a per-bin state
+        // vector that size and converges each bin to its own steady input
+        // without cross-bin interference, matching the existing
+        // `per_band_integration_is_independent` guarantee at daemon scale.
+        let n_bins = 32_769;
+        let targets: Vec<f64> = (0..n_bins).map(|i| -100.0 + (i % 60) as f64).collect();
+        let mut ema = EmaIntegrator::new(0.25, n_bins);
+        ema.update(&targets, 1e-3);
+        for _ in 0..500 {
+            ema.update(&targets, 0.0365);
+        }
+        let out = ema.update(&targets, 0.0365);
+        for (o, t) in out.iter().zip(&targets) {
+            assert!((o - t).abs() < 1e-3, "bin diverged: got {o}, want {t}");
+        }
+    }
+
     #[test]
     fn per_band_integration_is_independent() {
         // Feed a band-dependent pattern and check each band tracks

--- a/ac-rs/crates/ac-daemon/src/handlers/audio/monitor.rs
+++ b/ac-rs/crates/ac-daemon/src/handlers/audio/monitor.rs
@@ -123,6 +123,27 @@ fn push_loudness_with_optional_fir(
     }
 }
 
+/// LF-band FFT overlap fraction (#173). The previous un-overlapped block
+/// cadence (~0.7-1.4 s depending on `lf_fft_n`) recomputed the LF spectrum
+/// from entirely fresh samples each time; under broadband material each
+/// recompute is an independent chi-squared(2) draw per bin (~5.6 dB sigma,
+/// matching #173's measurement), so the LF half of the display lurched
+/// while the HF band (refreshed every tick) glided smoothly. 90% overlap
+/// keeps the 65536-point FFT's frequency resolution (needed to split
+/// closely-spaced LF tones, #142) while recomputing every
+/// `(1 - LF_OVERLAP) * lf_fft_n / sr` seconds instead of the full block —
+/// ~136 ms at the N=65536/48kHz default, under the ~170 ms cadence target.
+const LF_OVERLAP: f64 = 0.9;
+
+/// Power-domain EMA time constant applied to each newly-recomputed LF
+/// spectrum (#173), reusing `EmaIntegrator`'s existing fast/slow/Leq
+/// convention at per-bin scale. Tuned in
+/// `ac_core::visualize::time_integration::tests::lf_ema_brings_variance_within_2x_of_hf_target`
+/// to bring the raw ~5.6 dB chi-squared sigma down to ~2.2-2.4 dB, within
+/// 2x of the HF band's measured 0.7-2.4 dB range, without smearing tone
+/// levels (EMA is power-domain, unbiased at steady state).
+const LF_AVG_TAU_S: f64 = 0.25;
+
 /// Convert a possibly-infinite `f64` to JSON — `null` when not finite,
 /// real number otherwise. Keeps the sidecar frame JSON-parseable; `-inf`
 /// would otherwise fail `serde_json`'s finite-value check.
@@ -533,17 +554,21 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
         // Dual-resolution low-frequency path (#142). A second, longer ring
         // feeds an `lf_fft_n`-point FFT used only below `crossover_hz`; the
         // short `fft_rings` above keep driving the high band at the live
-        // refresh rate. The LF spectrum is recomputed at most once per LF
-        // block duration (`lf_fft_n / sr`) — LF content is slow-moving, so
-        // this caps the extra CPU instead of paying a long FFT every tick.
-        // `lf_spec_cache` holds the most recent LF linear half-spectrum per
-        // channel (`None` until its ring first fills).
+        // refresh rate. The LF spectrum is recomputed every `LF_OVERLAP`-hop
+        // (`(1 - LF_OVERLAP) * lf_fft_n / sr`, #173) rather than once per
+        // full block, and each new raw recompute is smoothed through a
+        // power-domain EMA (`lf_ema`) before caching — see `LF_OVERLAP` /
+        // `LF_AVG_TAU_S` above. `lf_spec_cache` holds the most recent
+        // smoothed LF linear half-spectrum per channel (`None` until its
+        // ring first fills).
         let mut lf_fft_rings: Vec<std::collections::VecDeque<f32>> = channels_worker
             .iter()
             .map(|_| std::collections::VecDeque::with_capacity(131_072))
             .collect();
         let mut lf_spec_cache: Vec<Option<Vec<f64>>> = vec![None; channels_worker.len()];
         let mut lf_ticks_since_recompute: Vec<u32> = vec![u32::MAX; channels_worker.len()];
+        let mut lf_ema: Vec<Option<EmaIntegrator>> = vec![None; channels_worker.len()];
+        let mut lf_ema_last_ts: Vec<Option<std::time::Instant>> = vec![None; channels_worker.len()];
 
         // Per-channel time-integration state for the `fractional_octave_leq`
         // sidecar frame. `None` until the first fractional_octave frame at
@@ -586,10 +611,12 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
             // than the live one — otherwise the live spectrum already has
             // equal-or-finer Δf everywhere.
             let lf_band_enabled = cur_lf_fft_n > cur_fft_n;
-            // Recompute the LF FFT at most once per LF block duration.
-            let lf_recompute_every = ((cur_lf_fft_n as f64 / sr as f64) / cur_interval.max(1e-6))
-                .round()
-                .clamp(1.0, 4096.0) as u32;
+            // Recompute the LF FFT every overlap-hop instead of once per
+            // full block (#173) — see `LF_OVERLAP`.
+            let lf_recompute_every = ((cur_lf_fft_n as f64 * (1.0 - LF_OVERLAP) / sr as f64)
+                / cur_interval.max(1e-6))
+            .round()
+            .clamp(1.0, 4096.0) as u32;
             let mode = analysis_mode.lock().unwrap().clone();
             let is_cwt = mode == "cwt";
             let is_cqt = mode == "cqt";
@@ -1167,7 +1194,34 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                             let lf_buf = lf_ring.make_contiguous();
                             let (lf_spec, _) =
                                 ac_core::visualize::spectrum::spectrum_only(lf_buf, sr);
-                            lf_spec_cache[idx] = Some(lf_spec);
+                            // Power-domain EMA smoothing (#173): re-init
+                            // whenever the bin count changes (lf_fft_n
+                            // change) so stale state never gets fed a
+                            // mismatched vector length.
+                            let n_bins = lf_spec.len();
+                            let ema_slot = &mut lf_ema[idx];
+                            if ema_slot
+                                .as_ref()
+                                .map(|e| e.state_len() != n_bins)
+                                .unwrap_or(true)
+                            {
+                                *ema_slot = Some(EmaIntegrator::new(LF_AVG_TAU_S, n_bins));
+                                lf_ema_last_ts[idx] = None;
+                            }
+                            let now = std::time::Instant::now();
+                            let dt = lf_ema_last_ts[idx]
+                                .map(|t| now.duration_since(t).as_secs_f64())
+                                .unwrap_or(cur_lf_fft_n as f64 * (1.0 - LF_OVERLAP) / sr as f64)
+                                .max(1e-6);
+                            lf_ema_last_ts[idx] = Some(now);
+                            let raw_db: Vec<f64> =
+                                lf_spec.iter().map(|&a| 20.0 * a.log10()).collect();
+                            let smoothed_db = ema_slot.as_mut().unwrap().update(&raw_db, dt);
+                            let smoothed_amp: Vec<f64> = smoothed_db
+                                .iter()
+                                .map(|&db| 10f64.powf(db / 20.0))
+                                .collect();
+                            lf_spec_cache[idx] = Some(smoothed_amp);
                             *counter = 0;
                         } else {
                             *counter = counter.saturating_add(1);
@@ -1179,6 +1233,8 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
                     lf_fft_rings[idx].clear();
                     lf_spec_cache[idx] = None;
                     lf_ticks_since_recompute[idx] = u32::MAX;
+                    lf_ema[idx] = None;
+                    lf_ema_last_ts[idx] = None;
                 }
                 let lf_spec_for_merge: Option<&[f64]> = if lf_band_enabled {
                     lf_spec_cache[idx].as_deref()
@@ -1393,11 +1449,13 @@ pub fn monitor_spectrum(state: &ServerState, cmd: &Value) -> Value {
     }
     json!({
         "ok": true,
-        "in_port":      primary_in_port,
-        "in_ports":     in_ports,
-        "channels":     channels,
-        "lf_fft_n":     lf_fft_n,
-        "crossover_hz": crossover_hz,
+        "in_port":         primary_in_port,
+        "in_ports":        in_ports,
+        "channels":        channels,
+        "lf_fft_n":        lf_fft_n,
+        "crossover_hz":    crossover_hz,
+        "lf_avg_tau_ms":   LF_AVG_TAU_S * 1000.0,
+        "lf_overlap_pct":  LF_OVERLAP * 100.0,
     })
 }
 

--- a/ac-rs/crates/ac-ui/src/app.rs
+++ b/ac-rs/crates/ac-ui/src/app.rs
@@ -257,6 +257,10 @@ pub struct App {
     /// The LF band is active only while `monitor_fft_n < monitor_lf_fft_n`.
     monitor_lf_fft_n: Option<u32>,
     monitor_crossover_hz: Option<f32>,
+    /// LF temporal-averaging settle info learned from the same reply
+    /// (#173) — daemon-owned EMA tau / overlap, purely for the readout.
+    monitor_lf_avg_tau_ms: Option<f64>,
+    monitor_lf_overlap_pct: Option<f64>,
     /// Insertion-order view of `selected`. Compare layout renders cells in
     /// selection order; the T key reads the first and last entries to form
     /// a virtual transfer pair (meas = first, ref = last).
@@ -598,6 +602,8 @@ impl App {
             monitor_fft_n: 8192,
             monitor_lf_fft_n: None,
             monitor_crossover_hz: None,
+            monitor_lf_avg_tau_ms: None,
+            monitor_lf_overlap_pct: None,
             selection_order: Vec::new(),
             config,
             cell_views: Vec::new(),

--- a/ac-rs/crates/ac-ui/src/app/control.rs
+++ b/ac-rs/crates/ac-ui/src/app/control.rs
@@ -405,6 +405,10 @@ impl App {
                         .get("crossover_hz")
                         .and_then(|v| v.as_f64())
                         .map(|v| v as f32);
+                    self.monitor_lf_avg_tau_ms =
+                        reply.get("lf_avg_tau_ms").and_then(|v| v.as_f64());
+                    self.monitor_lf_overlap_pct =
+                        reply.get("lf_overlap_pct").and_then(|v| v.as_f64());
                 } else {
                     let err = reply.get("error").and_then(|v| v.as_str()).unwrap_or("?");
                     self.notify(&format!("monitor_spectrum: {err}"));

--- a/ac-rs/crates/ac-ui/src/app/render_pipeline.rs
+++ b/ac-rs/crates/ac-ui/src/app/render_pipeline.rs
@@ -856,6 +856,8 @@ impl App {
             fft_n: self.monitor_fft_n,
             lf_fft_n: lf_active,
             crossover_hz: lf_active.and(self.monitor_crossover_hz),
+            lf_avg_tau_ms: lf_active.and(self.monitor_lf_avg_tau_ms),
+            lf_overlap_pct: lf_active.and(self.monitor_lf_overlap_pct),
         });
         // For the CQT badge we need the live `f_min` — the daemon
         // clamps it dynamically above the const default based on ring

--- a/ac-rs/crates/ac-ui/src/ui/fmt.rs
+++ b/ac-rs/crates/ac-ui/src/ui/fmt.rs
@@ -123,15 +123,21 @@ pub fn spectrum_readout(
 /// When `lf_fft_n` / `crossover_hz` are `Some` the dual-resolution LF path
 /// is active (#142) and a second line is appended (`\n`-separated): the
 /// HF (interactive) line gains a `≥ {crossover} Hz` scope tag and the LF
-/// line reports the long-FFT `N`, its finer `Δf`, and the LF block latency.
-/// When `None` the output is byte-for-byte today's single line — the
-/// fallback for daemons without the feature or when live N ≥ LF N.
+/// line reports the long-FFT `N`, its finer `Δf`, the recompute cadence
+/// (`lf_avg_tau_ms`/`lf_overlap_pct` when present, #173 — replaces the
+/// stale full-block-latency figure now that LF recomputes overlap), and
+/// the EMA time constant smoothing it. When `None` the output is
+/// byte-for-byte today's single line — the fallback for daemons without
+/// the feature or when live N ≥ LF N.
+#[allow(clippy::too_many_arguments)]
 pub fn monitor_knobs_readout(
     interval_ms: u32,
     fft_n: u32,
     sr: u32,
     lf_fft_n: Option<u32>,
     crossover_hz: Option<f32>,
+    lf_avg_tau_ms: Option<f64>,
+    lf_overlap_pct: Option<f64>,
 ) -> String {
     let df = sr as f32 / fft_n.max(1) as f32;
     let hf = format!("{:>4} ms  │  N {}  │  Δf {:.1} Hz", interval_ms, fft_n, df);
@@ -139,10 +145,19 @@ pub fn monitor_knobs_readout(
     match (lf_fft_n, crossover_hz) {
         (Some(lf_n), Some(cx)) => {
             let lf_df = sr as f32 / lf_n.max(1) as f32;
-            // LF block latency = N / sr — the inherent slow-update trade-off.
-            let lf_latency_s = lf_n as f32 / sr.max(1) as f32;
+            // Recompute cadence with overlap (#173): (1 - overlap) * N / sr,
+            // the actual update rate now — no longer the full block duration.
+            let overlap_frac = lf_overlap_pct.unwrap_or(0.0) / 100.0;
+            let lf_cadence_s = lf_n as f64 * (1.0 - overlap_frac) / sr.max(1) as f64;
+            let settle = match lf_avg_tau_ms {
+                Some(tau_ms) => format!(
+                    " · τ {tau_ms:.0} ms @ {:.0}% ovl",
+                    lf_overlap_pct.unwrap_or(0.0)
+                ),
+                None => String::new(),
+            };
             format!(
-                "{hf}   ≥ {cx:.0} Hz\nLF     │  N {lf_n}  │  Δf {} Hz  < {cx:.0} Hz · {lf_latency_s:.1} s",
+                "{hf}   ≥ {cx:.0} Hz\nLF     │  N {lf_n}  │  Δf {} Hz  < {cx:.0} Hz · {lf_cadence_s:.3} s{settle}",
                 fmt_delta_f(lf_df),
             )
         }
@@ -1122,19 +1137,19 @@ mod tests {
     #[test]
     fn monitor_knobs_delta_f_math() {
         // Δf = sr / N. 48000 / 4096 = 11.71875 → rounds to "11.7 Hz".
-        let s = monitor_knobs_readout(10, 4096, 48_000, None, None);
+        let s = monitor_knobs_readout(10, 4096, 48_000, None, None, None, None);
         assert!(s.contains("Δf 11.7 Hz"), "got: {s}");
         // 96 kHz, N = 8192 → 11.71875 as well.
-        let s = monitor_knobs_readout(10, 8192, 96_000, None, None);
+        let s = monitor_knobs_readout(10, 8192, 96_000, None, None, None, None);
         assert!(s.contains("Δf 11.7 Hz"), "got: {s}");
         // 48 kHz, N = 2048 → 23.4375 → "23.4 Hz".
-        let s = monitor_knobs_readout(5, 2048, 48_000, None, None);
+        let s = monitor_knobs_readout(5, 2048, 48_000, None, None, None, None);
         assert!(s.contains("Δf 23.4 Hz"), "got: {s}");
     }
 
     #[test]
     fn monitor_knobs_formats_interval_and_n() {
-        let s = monitor_knobs_readout(7, 16384, 48_000, None, None);
+        let s = monitor_knobs_readout(7, 16384, 48_000, None, None, None, None);
         assert!(s.contains("   7 ms"));
         assert!(s.contains("N 16384"));
     }
@@ -1142,15 +1157,23 @@ mod tests {
     #[test]
     fn monitor_knobs_zero_n_does_not_panic() {
         // Defensive guard — mp.fft_n.max(1).
-        let _ = monitor_knobs_readout(1, 0, 48_000, None, None);
-        let _ = monitor_knobs_readout(1, 8192, 48_000, Some(0), Some(750.0));
+        let _ = monitor_knobs_readout(1, 0, 48_000, None, None, None, None);
+        let _ = monitor_knobs_readout(
+            1,
+            8192,
+            48_000,
+            Some(0),
+            Some(750.0),
+            Some(250.0),
+            Some(90.0),
+        );
     }
 
     #[test]
     fn monitor_knobs_single_line_fallback_is_unchanged() {
         // `None` LF params → today's exact one-line output, no LF line,
         // no `≥` scope tag (#142 fallback).
-        let s = monitor_knobs_readout(10, 16384, 48_000, None, None);
+        let s = monitor_knobs_readout(10, 16384, 48_000, None, None, None, None);
         assert_eq!(s, "  10 ms  │  N 16384  │  Δf 2.9 Hz");
         assert!(!s.contains('\n'));
         assert!(!s.contains("LF"));
@@ -1159,24 +1182,37 @@ mod tests {
 
     #[test]
     fn monitor_knobs_two_line_when_lf_active() {
-        // HF N=16384 @ 48k → Δf 2.9 Hz; LF N=65536 → Δf 0.73 Hz, latency 1.4 s.
-        let s = monitor_knobs_readout(10, 16384, 48_000, Some(65536), Some(750.0));
+        // HF N=16384 @ 48k → Δf 2.9 Hz; LF N=65536 → Δf 0.73 Hz. Overlap
+        // 90% / tau 250ms (#173) → recompute cadence ~0.137 s, far under
+        // the stale non-overlapped 1.37 s full-block figure.
+        let s = monitor_knobs_readout(
+            10,
+            16384,
+            48_000,
+            Some(65536),
+            Some(750.0),
+            Some(250.0),
+            Some(90.0),
+        );
         let lines: Vec<&str> = s.lines().collect();
         assert_eq!(lines.len(), 2, "expected two lines, got: {s:?}");
         // HF line keeps its byte-for-byte knobs and gains the scope tag.
         assert!(lines[0].starts_with("  10 ms  │  N 16384  │  Δf 2.9 Hz"));
         assert!(lines[0].contains("≥ 750 Hz"));
-        // LF line: long N, sub-Hz Δf at 2 decimals, crossover + latency.
+        // LF line: long N, sub-Hz Δf at 2 decimals, crossover, overlapped
+        // cadence (not the old 1.4 s full-block latency), and the EMA tau.
         assert!(lines[1].contains("N 65536"));
         assert!(lines[1].contains("Δf 0.73 Hz"), "got: {}", lines[1]);
         assert!(lines[1].contains("< 750 Hz"));
-        assert!(lines[1].contains("· 1.4 s"));
+        assert!(lines[1].contains("0.137 s"), "got: {}", lines[1]);
+        assert!(lines[1].contains("τ 250 ms"), "got: {}", lines[1]);
+        assert!(lines[1].contains("90% ovl"), "got: {}", lines[1]);
     }
 
     #[test]
     fn monitor_knobs_lf_delta_f_adaptive_decimals() {
         // LF Δf ≥ 10 Hz uses 1 decimal (e.g. tiny LF N); < 10 Hz uses 2.
-        let s = monitor_knobs_readout(10, 1024, 48_000, Some(2048), Some(750.0));
+        let s = monitor_knobs_readout(10, 1024, 48_000, Some(2048), Some(750.0), None, None);
         // 48000/2048 = 23.4375 → "23.4" (1 decimal).
         assert!(s.contains("Δf 23.4 Hz"), "got: {s}");
     }

--- a/ac-rs/crates/ac-ui/src/ui/overlay.rs
+++ b/ac-rs/crates/ac-ui/src/ui/overlay.rs
@@ -196,6 +196,11 @@ pub struct MonitorParamsInfo {
     /// line. `None` → single-line fallback (today's exact output).
     pub lf_fft_n: Option<u32>,
     pub crossover_hz: Option<f32>,
+    /// LF temporal-averaging settle info (#173) — daemon-reported EMA tau
+    /// and overlap fraction, echoed on the LF readout line. `None` on a
+    /// daemon predating #173 (or when the LF band itself is inactive).
+    pub lf_avg_tau_ms: Option<f64>,
+    pub lf_overlap_pct: Option<f64>,
 }
 
 // Help overlay — RC-9 trim, ≤30 lines, organized by view family. The
@@ -420,6 +425,8 @@ pub fn draw(ctx: &Context, input: OverlayInput<'_>) {
                     sr,
                     mp.lf_fft_n,
                     mp.crossover_hz,
+                    mp.lf_avg_tau_ms,
+                    mp.lf_overlap_pct,
                 );
                 for mon_line in mon_text.lines() {
                     painter.text(


### PR DESCRIPTION
closes #173

### what changed
The LF FFT path (65536-pt, un-overlapped, one recompute per ~1.37 s block) made the left half of the spectrum display lurch on raw chi-squared(2) periodogram statistics (~5.6 dB sigma, matching the issue's measurement) while the HF band read as smooth. This recomputes the LF FFT on a 90% overlap hop (~136 ms instead of ~1.37 s, under the ≤170 ms target) and smooths each new raw periodogram through `EmaIntegrator` (tau=250ms) in the power domain before caching — reusing the same primitive already trusted for octave-band fast/slow/Leq, generalized here to the LF bin count (32769 bins) rather than adding a new averaging primitive.

Per architect design decision (comment on #173): averaging lives daemon-side, before publish, so any wire consumer sees an already-representative LF spectrum — same principle as the existing octave-band EMA and the #169 domain fix. Status header now reports the EMA tau and overlap fraction instead of the stale full-block-latency figure.

### files touched
- `ac-core/src/visualize/time_integration.rs` — new tests validating `EmaIntegrator` generalizes to LF bin count without bias, and tuning `LF_OVERLAP`/`LF_AVG_TAU_S` against a chi-squared(2) periodogram model (reproduces the issue's ~5.6 dB sigma, confirms post-EMA sigma lands within 2x of a representative HF reference). No production code change — the primitive was already generic enough to reuse as-is.
- `ac-daemon/src/handlers/audio/monitor.rs` — `LF_OVERLAP`/`LF_AVG_TAU_S` constants; LF recompute cadence now hop-based instead of full-block; each raw LF recompute is EMA-smoothed (amplitude→dB→power-domain EMA→dB→amplitude) before caching; EMA/timestamp state reset on bin-count change or LF-band disable; CTRL reply gains `lf_avg_tau_ms`/`lf_overlap_pct`.
- `ac-ui/src/ui/fmt.rs` — `monitor_knobs_readout()` takes the two new optional fields and appends the EMA tau/overlap and updated (overlapped) cadence to the LF readout line, replacing the stale full-block-latency number.
- `ac-ui/src/app.rs`, `ac-ui/src/app/control.rs`, `ac-ui/src/app/render_pipeline.rs`, `ac-ui/src/ui/overlay.rs` — thread `lf_avg_tau_ms`/`lf_overlap_pct` from the CTRL reply through app state / `MonitorParamsInfo` to the readout call.

### test output
```
ac-core:   283 passed; 0 failed
ac-daemon:  65 passed; 0 failed
ac-ui:     219 passed; 0 failed
(+ it_cross_tier_parity: 4, it_protocol: 49, all passing; it_display_truth/it_views_smoke ignored — need a wgpu adapter, runbook-only per #170)
```
`cargo clippy --workspace -- -D warnings` and `cargo fmt --check` both clean.

### ZMQ schema changed
Additive only: `monitor_spectrum` CTRL reply gains `lf_avg_tau_ms` (f64) and `lf_overlap_pct` (f64). No change to the PUB frame schema or `ac::session`; `ds` unaffected.

### new dependencies
none

### related
none

### open questions for reviewer
- `LF_OVERLAP = 0.9` / `LF_AVG_TAU_S = 0.25s` are my chosen constants, justified analytically + by the synthetic chi-squared(2) test in `time_integration.rs` (raw ~5.57 dB sigma → ~2.2-2.4 dB post-EMA, within 2x of a 1.5 dB HF reference point taken from the issue's measured 0.7-2.4 dB range). Per the issue, the *permanent* I2 variance threshold and hardware-verified before/after numbers are QA's job post-merge (no I2 assertion exists in `it_display_truth.rs` yet to extend) — this PR's numbers come from a pure synthetic model, not a live capture on the RADV rig, since the harness's I1/I3/I4 tests are hardware-gated and out of my reach in this environment. QA should re-verify the real per-band variance ratio on hardware before locking the I2 threshold.
- I did not add a client-facing LF overlap/tau knob — matches the issue's explicit out-of-scope note (no change to crossover/N/wire format) and the architect's affected-modules list, which didn't call for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)