### PR TITLE
test: I5 soak — temporal display-truth invariant for LF spectrum band

### DIFF
--- a/.agents/qa.md
+++ b/.agents/qa.md
@@ -267,3 +267,19 @@ wrong without any test catching it. These are the highest priority.}
   changes internal correctness checks (CSV export, cursor readout) while the
   harness is red is not `qa-approved` — that gap is exactly what #170 exists
   to close.
+- Do not approve a value-display PR or a daemon-pipeline PR (anything
+  touching `ac-daemon/src/handlers/audio/monitor.rs`, the ring buffers /
+  time-integration state feeding it, or the display buffer it publishes
+  into) without the I5 soak (`ac-ui --headless-test`'s "I5 soak" checks,
+  same binary as T1-T4, handoff.md) reporting green in addition to I1-I4.
+  I1-I4 are single-snapshot checks — settle, read one frame, judge — and
+  are structurally blind to any bug with onset delay (ring-buffer wrap,
+  EMA/state poisoning, cadence-boundary mishandling). I5 runs a seeded
+  deterministic fake-audio stimulus for long enough to exceed every
+  internal buffer period (derived from the daemon's own reported
+  `lf_fft_n`/`lf_overlap_pct`/`lf_avg_tau_ms`, not hardcoded) and asserts
+  I4-t bounded / I2-t continuity / I5a liveness / I5b plausibility on
+  every published frame, not just the last one. On first violation it
+  dumps frames N-1/N/N+1 as CSVs with the elapsed-time-to-violation —
+  treat that dump as the debugging input for the fix, the same way the
+  HF-garbage fixture corpus works for I4.

--- a/ac-rs/crates/ac-daemon/src/audio/fake.rs
+++ b/ac-rs/crates/ac-daemon/src/audio/fake.rs
@@ -12,6 +12,7 @@
 //! offsets for the measurement and reference channels.
 
 use anyhow::Result;
+use std::collections::HashMap;
 use std::f64::consts::PI;
 use std::time::Duration;
 
@@ -47,6 +48,19 @@ pub struct FakeEngine {
     output_ports: Vec<String>,
     input_port: Option<String>,
     ref_port: Option<String>,
+    /// Per-channel-offset LCG state for `Stimulus::Noise`, keyed on the
+    /// offset's bit pattern (one entry per distinct channel). Persisted
+    /// across `capture_block`/`capture_stereo` calls so a soak driving the
+    /// I5 display-truth invariant (handoff.md) sees a genuine continuing
+    /// pseudorandom stream rather than the same block on every tick — the
+    /// LCG used to be re-seeded to the same fixed state on every single
+    /// call (state was a local var in `make_samples_for`, `&self`), so a
+    /// ring buffer fed one identical block per tick became a periodic
+    /// buffer after wrapping, freezing the FFT output on whatever comb
+    /// spectrum that periodicity produced. Reproducible from a fresh
+    /// engine (same offset -> same starting state) so replay from a
+    /// logged seed still works; see `noise_stream_advances_across_calls`.
+    noise_state: HashMap<u64, u64>,
 }
 
 impl FakeEngine {
@@ -58,6 +72,7 @@ impl FakeEngine {
             output_ports: Vec::new(),
             input_port: None,
             ref_port: None,
+            noise_state: HashMap::new(),
         }
     }
 
@@ -90,7 +105,7 @@ impl FakeEngine {
 
     /// Generate `duration` seconds of synthetic signal for `port`'s channel
     /// (frequency-shifted per `CHANNEL_OFFSET_HZ`, same as pre-#170).
-    fn make_samples_for(&self, port: Option<&str>, duration: f64) -> Vec<f32> {
+    fn make_samples_for(&mut self, port: Option<&str>, duration: f64) -> Vec<f32> {
         let n = (self.sample_rate as f64 * duration) as usize;
         let offset = Self::channel_offset_hz(port);
         let sr = self.sample_rate as f64;
@@ -128,13 +143,22 @@ impl FakeEngine {
                 // pink/white — good enough as a calibrated-amplitude
                 // broadband stimulus for I2, which checks for band-boundary
                 // steps rather than an exact spectral shape.
-                let mut state: u64 = 0x9E3779B97F4A7C15 ^ offset.to_bits();
+                //
+                // State persists in `self.noise_state` across calls (keyed
+                // by the channel offset) so consecutive captures continue
+                // the same pseudorandom stream instead of each replaying an
+                // identical block — see the field doc on `noise_state`.
+                let key = offset.to_bits();
+                let state = self
+                    .noise_state
+                    .entry(key)
+                    .or_insert(0x9E3779B97F4A7C15 ^ key);
                 (0..n)
                     .map(|_| {
-                        state = state
+                        *state = state
                             .wrapping_mul(6364136223846793005)
                             .wrapping_add(1442695040888963407);
-                        let u = ((state >> 40) as f64 / (1u64 << 24) as f64) * 2.0 - 1.0;
+                        let u = ((*state >> 40) as f64 / (1u64 << 24) as f64) * 2.0 - 1.0;
                         (amp * u) as f32
                     })
                     .collect()
@@ -178,7 +202,8 @@ impl AudioEngine for FakeEngine {
 
     fn capture_block(&mut self, duration: f64) -> Result<Vec<f32>> {
         std::thread::sleep(Duration::from_secs_f64(duration));
-        Ok(self.make_samples_for(self.input_port.as_deref(), duration))
+        let port = self.input_port.clone();
+        Ok(self.make_samples_for(port.as_deref(), duration))
     }
 
     /// Fake loopback: returns `samples` delayed by a fixed number of
@@ -203,8 +228,10 @@ impl AudioEngine for FakeEngine {
     fn capture_stereo(&mut self, duration: f64) -> Result<(Vec<f32>, Vec<f32>)> {
         std::thread::sleep(Duration::from_secs_f64(duration));
         // If no explicit ref_port, reference mirrors the generator (channel 0).
-        let meas = self.make_samples_for(self.input_port.as_deref(), duration);
-        let refch = self.make_samples_for(self.ref_port.as_deref(), duration);
+        let in_port = self.input_port.clone();
+        let ref_port = self.ref_port.clone();
+        let meas = self.make_samples_for(in_port.as_deref(), duration);
+        let refch = self.make_samples_for(ref_port.as_deref(), duration);
         Ok((meas, refch))
     }
 
@@ -343,6 +370,47 @@ mod tests {
             m1 > m2,
             "louder tone (0.5) should measure higher than quieter tone (0.1): {m1} vs {m2}"
         );
+    }
+
+    /// Regression for the frozen/repeated-block bug the I5 soak invariant
+    /// exists to catch (`handoff.md`): before the fix, `Stimulus::Noise`
+    /// re-seeded its LCG to the same fixed state on every `capture_block`
+    /// call, so a caller polling repeatedly (as `monitor_spectrum`'s LF
+    /// ring does) saw the identical block over and over — a ring fed only
+    /// identical blocks becomes periodic once fully wrapped, freezing
+    /// whatever spectrum falls out of that periodicity. Two consecutive
+    /// captures must now differ.
+    #[test]
+    fn noise_stream_advances_across_calls() {
+        let mut eng = FakeEngine::new();
+        eng.set_broadband_noise(0.5);
+        eng.reconnect_input("fake:capture_0").unwrap();
+        let a = eng.capture_block(0.01).unwrap();
+        let b = eng.capture_block(0.01).unwrap();
+        assert_eq!(a.len(), b.len());
+        assert_ne!(
+            a, b,
+            "consecutive noise captures must not repeat the same block"
+        );
+    }
+
+    /// Same starting state (fresh engine, same channel) must reproduce the
+    /// same first block — the soak's "same seed -> same result" acceptance
+    /// criterion (handoff.md) depends on this, not just on the stream
+    /// advancing.
+    #[test]
+    fn noise_stream_is_deterministic_from_a_fresh_engine() {
+        let mut eng1 = FakeEngine::new();
+        eng1.set_broadband_noise(0.5);
+        eng1.reconnect_input("fake:capture_0").unwrap();
+        let first = eng1.capture_block(0.01).unwrap();
+
+        let mut eng2 = FakeEngine::new();
+        eng2.set_broadband_noise(0.5);
+        eng2.reconnect_input("fake:capture_0").unwrap();
+        let replay = eng2.capture_block(0.01).unwrap();
+
+        assert_eq!(first, replay, "same seed must replay identically");
     }
 
     #[test]

--- a/ac-rs/crates/ac-ui/src/headless.rs
+++ b/ac-rs/crates/ac-ui/src/headless.rs
@@ -18,6 +18,7 @@
 //! `HeadlessGpu` requests a device directly from an adapter with
 //! `compatible_surface: None`.
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
@@ -178,19 +179,26 @@ fn run_checked(
 
     // ── T3: render capture 1 through the real Spectrum + SpectrumEmber
     //    paint code and check pixel-level I1 apex + I3 orientation ──
-    match HeadlessGpu::new() {
-        Ok(gpu) => {
-            run_t3_checks(checks, &gpu, &frame1, f_lo, -6.0, f_hi, -18.0);
+    // Kept around (rather than dropped after this block) so the I5 soak
+    // below can reuse the same adapter for its periodic T3 sampling
+    // instead of standing up a second wgpu instance.
+    let gpu = match HeadlessGpu::new() {
+        Ok(gpu) => Some(gpu),
+        Err(e) => {
+            checks.push(Check {
+                name: "T3 GPU adapter".to_string(),
+                pass: false,
+                detail: format!(
+                    "no wgpu adapter available ({e}) — T3 checks require a software (lavapipe) \
+                     or real Vulkan/GL adapter; see runbook, this is expected on a host with no \
+                     GPU/driver stack"
+                ),
+            });
+            None
         }
-        Err(e) => checks.push(Check {
-            name: "T3 GPU adapter".to_string(),
-            pass: false,
-            detail: format!(
-                "no wgpu adapter available ({e}) — T3 checks require a software (lavapipe) \
-                 or real Vulkan/GL adapter; see runbook, this is expected on a host with no \
-                 GPU/driver stack"
-            ),
-        }),
+    };
+    if let Some(gpu) = &gpu {
+        run_t3_checks(checks, gpu, &frame1, f_lo, -6.0, f_hi, -18.0);
     }
 
     // ── Capture 2: two tones straddling the interpolation→aggregation
@@ -257,7 +265,691 @@ fn run_checked(
     );
     check_i2_variance_report(checks, &frame3);
 
+    // ── I5 soak: the temporal invariant (handoff.md) — snapshot checks
+    // above settle, read one frame, judge. Any bug with onset delay
+    // (ring-buffer wrap, EMA poisoning, cadence-boundary mishandling) is
+    // structurally invisible to them. Run seeded broadband noise for
+    // long enough to exceed every internal buffer period and assert on
+    // every published frame, not just one.
+    run_i5_soak(checks, &ctrl, &mut store, &cfg, gpu.as_ref())?;
+
     let _ = ctrl.send(&json!({"cmd": "stop"}));
+    Ok(())
+}
+
+// ── I5 soak — temporal display-truth invariant (handoff.md) ──
+
+/// Explicit floor the handoff calls out directly ("Run ≥ 15 s").
+const I5_SOAK_MIN_FLOOR_S: f64 = 15.0;
+
+/// The soak must exceed the LF window period by this multiple (handoff.md:
+/// "must exceed every internal buffer period in the system by a margin").
+/// At current defaults (65536/48000 ~= 1.365 s) this term (~13.6 s) is
+/// under `I5_SOAK_MIN_FLOOR_S`, which is the binding floor today; this
+/// term takes over automatically if `lf_fft_n` ever grows enough to need
+/// more than 15 s to see a wrap with margin.
+const I5_SOAK_WINDOW_MARGIN: f64 = 10.0;
+
+/// Injected broadband-noise level for the soak stimulus. Clear of 0 dBFS
+/// (I4-t headroom) and clear of the noise floor so collapse/garbage/drift
+/// is unambiguous against this reference.
+const I5_NOISE_DBFS: f64 = -20.0;
+
+/// Number of post-settle frames averaged into the I5b plausibility
+/// baseline before later frames are compared against it.
+const I5_BASELINE_FRAMES: usize = 5;
+
+/// I5a: LF content frozen for more than this many expected hops is a
+/// liveness violation (handoff.md: "frozen LF beyond 2x expected hop").
+const I5_LIVENESS_HOP_MULTIPLE: f64 = 2.0;
+
+/// I5b tolerance: LF band mean (power-domain) vs. its own post-settle
+/// baseline. Generous relative to the ~2.2-2.4 dB post-EMA sigma the
+/// `#173` tuning test (`lf_ema_brings_variance_within_2x_of_hf_target`)
+/// targets, so this catches collapse/garbage/drift, not EMA's own
+/// expected residual variance.
+const I5_PLAUSIBILITY_TOLERANCE_DB: f64 = 6.0;
+
+/// I2-t tolerance for the LF/HF splice step on every frame. Generous
+/// relative to the documented per-band sigma (HF ~0.7-2.4 dB, LF
+/// post-EMA target ~2x that) since the two bands are independent
+/// estimates that need not agree bin-for-bin, only avoid a gross jump.
+const I5_CONTINUITY_TOLERANCE_DB: f64 = 8.0;
+
+/// Consecutive out-of-tolerance frames required before continuity
+/// declares a violation. A single-frame crossing of a statistical
+/// tolerance is expected occasionally from broadband-noise chi-squared
+/// tails even with no bug present (observed empirically: a lone 8.16 dB
+/// splice step out of 327 frames in a 69 s run, against an 8 dB
+/// tolerance); the handoff's own failure-mode taxonomy is about
+/// *sustained* deviation (frozen / permanent-until-restart / cyclic at a
+/// period), not a lone outlier, so requiring a short run confirms a real
+/// break rather than flagging normal tail variance.
+const I5_SUSTAINED_STREAK_FRAMES: u32 = 3;
+
+/// I5b uses a rolling window rather than a strict consecutive streak: a
+/// bug that keeps updating but with wrong information doesn't necessarily
+/// stay out of tolerance on every single frame (a partially-correct or
+/// oscillating readout can dip back into tolerance between bad samples),
+/// which would reset a strict streak counter to zero and never fire. A
+/// majority-of-window vote catches that pattern as well as a sustained
+/// one, while a single blip in a `I5_PLAUSIBILITY_WINDOW`-sized window
+/// still can't cross the majority threshold.
+const I5_PLAUSIBILITY_WINDOW: usize = 10;
+const I5_PLAUSIBILITY_WINDOW_MIN_VIOLATIONS: usize = 5;
+
+/// Minimum number of observed LF-content-change intervals before I5c
+/// judges the update rate — too few samples make a mean interval noisy.
+const I5_RATE_MIN_SAMPLES: u32 = 5;
+
+/// I5c: the LF band's actual update cadence (mean interval between
+/// genuine content changes) must stay within this factor of the expected
+/// hop in either direction. Loose relative to `I5_LIVENESS_HOP_MULTIPLE`
+/// (2x, for "stopped changing entirely") because this check instead
+/// catches a band that *keeps* updating but at the wrong rate — e.g.
+/// recomputing every tick instead of every overlap-hop (losing the EMA
+/// smoothing that makes the recompute cadence meaningful) or, in the
+/// other direction, silently under-refreshing. Reported in the same
+/// dump as a "wrong information" failure, not just "frozen" — a bug can
+/// keep visibly updating and still be wrong (issue feedback: LF "continues
+/// to update with wrong rate ... and wrong information").
+const I5_RATE_TOLERANCE_FACTOR: f64 = 3.0;
+
+/// Poll cadence for reading the store while soaking. Well under the
+/// fastest internal cadence (LF hop ~136 ms at defaults) so no published
+/// frame is skipped between polls.
+const I5_POLL_INTERVAL_MS: u64 = 15;
+
+/// Fixed LF column T3 samples each ~1 Hz tick. Safely mid-band (well clear
+/// of the crossover and the plot's low-frequency edge) so a line-strip
+/// renderer always has a preceding point to draw from.
+const I5_T3_SAMPLE_FREQ_HZ: f64 = 100.0;
+
+/// Cadence between T3 samples. Looser than 1 Hz since each sample re-runs
+/// `render_ember_pixels`'s ~90-tick phosphor warm-up; periodic per the
+/// handoff's own wording, not a hard 1 Hz requirement.
+const I5_T3_SAMPLE_PERIOD_S: f64 = 3.0;
+
+#[derive(Clone)]
+struct SoakFrame {
+    elapsed_s: f64,
+    ts_ns: u64,
+    freqs: Arc<Vec<f32>>,
+    spectrum: Arc<Vec<f32>>,
+}
+
+struct SoakViolation {
+    /// Which invariant tripped — used to route pass/fail to the right
+    /// `Check` entry. One of "bounded" | "continuity" | "liveness" |
+    /// "plausibility".
+    source: &'static str,
+    /// Descriptive failure-mode word for the dump/report — one of the
+    /// four classes handoff.md asks QA to record (frozen / garbage /
+    /// level-jump / drift-as-cyclic-recovering-proxy).
+    class: &'static str,
+    detail: String,
+}
+
+/// Split index: LF = `freqs[..split]`, HF = `freqs[split..]`.
+fn lf_split(freqs: &[f32], crossover_hz: f64) -> usize {
+    freqs
+        .iter()
+        .position(|&f| f as f64 >= crossover_hz)
+        .unwrap_or(freqs.len())
+}
+
+/// Power-domain mean of a dBFS slice: `10*log10(mean(10^(v/10)))`, not a
+/// bare mean of dB values — consistent with `EmaIntegrator`'s own
+/// power-domain convention (`time_integration.rs`).
+fn power_mean_db(vals: &[f32]) -> f64 {
+    if vals.is_empty() {
+        return f64::NEG_INFINITY;
+    }
+    let mean_pow = vals
+        .iter()
+        .map(|&v| 10f64.powf(v as f64 / 10.0))
+        .sum::<f64>()
+        / vals.len() as f64;
+    10.0 * mean_pow.log10()
+}
+
+/// Incremental per-frame checker for the I5 soak — O(1) state per frame
+/// rather than re-scanning full history, so the soak can run indefinitely
+/// without unbounded memory. Checks run in a fixed priority order per
+/// frame (bounded > continuity > liveness > plausibility); only the first
+/// violation across the whole run is reported (handoff.md: "on first
+/// violation").
+struct SoakState {
+    crossover_hz: f64,
+    expected_hop_s: f64,
+    settle_s: f64,
+    bounded_tol_db: f64,
+    continuity_tol_db: f64,
+    liveness_hop_multiple: f64,
+    plausibility_tol_db: f64,
+
+    last_lf: Option<Vec<f32>>,
+    last_change_elapsed_s: f64,
+    baseline_samples: Vec<f64>,
+    baseline_mean_db: Option<f64>,
+    continuity_streak: u32,
+    plausibility_window: std::collections::VecDeque<bool>,
+    rate_interval_count: u32,
+    rate_interval_sum_s: f64,
+
+    checked_bounded: bool,
+    checked_continuity: bool,
+    checked_liveness: bool,
+    checked_plausibility: bool,
+    checked_rate: bool,
+}
+
+impl SoakState {
+    fn new(crossover_hz: f64, expected_hop_s: f64, settle_s: f64) -> Self {
+        Self {
+            crossover_hz,
+            expected_hop_s,
+            settle_s,
+            bounded_tol_db: I4_TOLERANCE_DB,
+            continuity_tol_db: I5_CONTINUITY_TOLERANCE_DB,
+            liveness_hop_multiple: I5_LIVENESS_HOP_MULTIPLE,
+            plausibility_tol_db: I5_PLAUSIBILITY_TOLERANCE_DB,
+            last_lf: None,
+            last_change_elapsed_s: 0.0,
+            baseline_samples: Vec::with_capacity(I5_BASELINE_FRAMES),
+            baseline_mean_db: None,
+            continuity_streak: 0,
+            plausibility_window: std::collections::VecDeque::with_capacity(I5_PLAUSIBILITY_WINDOW),
+            rate_interval_count: 0,
+            rate_interval_sum_s: 0.0,
+            checked_bounded: false,
+            checked_continuity: false,
+            checked_liveness: false,
+            checked_plausibility: false,
+            checked_rate: false,
+        }
+    }
+
+    /// Returns the first violation found in `sf`, if any. Runs every
+    /// sub-check that has enough state, marking each as "exercised" so the
+    /// caller can report an honest "never triggered" vs. "never ran" if
+    /// the soak stops early.
+    fn check_frame(&mut self, sf: &SoakFrame) -> Option<SoakViolation> {
+        // I4-t bounded: no value > 0 dBFS + tolerance, no NaN/Inf, ever.
+        self.checked_bounded = true;
+        for &v in sf.spectrum.iter() {
+            if !v.is_finite() {
+                return Some(SoakViolation {
+                    source: "bounded",
+                    class: "garbage",
+                    detail: format!(
+                        "non-finite value {v:?} in published frame at t={:.3}s",
+                        sf.elapsed_s
+                    ),
+                });
+            }
+            if v as f64 > self.bounded_tol_db {
+                return Some(SoakViolation {
+                    source: "bounded",
+                    class: "level-jump",
+                    detail: format!(
+                        "value {v:.3} dBFS exceeds bound (0 dBFS + {} dB tol) at t={:.3}s",
+                        self.bounded_tol_db, sf.elapsed_s
+                    ),
+                });
+            }
+        }
+
+        // I2-t continuity: LF/HF splice step bounded on every frame.
+        let split = lf_split(&sf.freqs, self.crossover_hz);
+        if split > 0 && split < sf.spectrum.len() {
+            self.checked_continuity = true;
+            let step = (sf.spectrum[split] - sf.spectrum[split - 1]).abs() as f64;
+            if step > self.continuity_tol_db {
+                self.continuity_streak += 1;
+                if self.continuity_streak >= I5_SUSTAINED_STREAK_FRAMES {
+                    return Some(SoakViolation {
+                        source: "continuity",
+                        class: "level-jump",
+                        detail: format!(
+                            "LF/HF splice step {step:.2} dB at t={t:.3}s exceeds tolerance \
+                             ({tol} dB) for {streak} consecutive frames — LF col \
+                             {lf_hz:.1}Hz={lf_db:.2}dBFS, HF col {hf_hz:.1}Hz={hf_db:.2}dBFS",
+                            t = sf.elapsed_s,
+                            tol = self.continuity_tol_db,
+                            streak = self.continuity_streak,
+                            lf_hz = sf.freqs[split - 1],
+                            lf_db = sf.spectrum[split - 1],
+                            hf_hz = sf.freqs[split],
+                            hf_db = sf.spectrum[split],
+                        ),
+                    });
+                }
+            } else {
+                self.continuity_streak = 0;
+            }
+        }
+
+        let lf = &sf.spectrum[..split];
+        if !lf.is_empty() {
+            // I5a liveness: LF content must change within 2x expected hop.
+            // Catches "stopped updating entirely" — a distinct failure
+            // mode from I5c below, which catches "keeps updating, but at
+            // the wrong rate."
+            self.checked_liveness = true;
+            let changed = match &self.last_lf {
+                Some(prev) => {
+                    prev.len() != lf.len() || prev.iter().zip(lf).any(|(a, b)| (a - b).abs() > 1e-4)
+                }
+                None => true,
+            };
+            if changed {
+                let prev_change_elapsed_s = self.last_change_elapsed_s;
+                let is_first_change = self.last_lf.is_none();
+                self.last_change_elapsed_s = sf.elapsed_s;
+                self.last_lf = Some(lf.to_vec());
+
+                // I5c update rate: track the interval between genuine LF
+                // content changes (not just whether it changed) once
+                // settled. A bug that keeps visibly updating but at the
+                // wrong cadence — e.g. recomputing every tick instead of
+                // every overlap-hop, losing the EMA smoothing that makes
+                // the cadence meaningful, or the opposite,
+                // under-refreshing — is invisible to I5a (which only
+                // fires on a full stop) but shows up here as a mean
+                // interval far from `expected_hop_s`.
+                if !is_first_change && sf.elapsed_s >= self.settle_s {
+                    self.checked_rate = true;
+                    let interval = sf.elapsed_s - prev_change_elapsed_s;
+                    self.rate_interval_sum_s += interval;
+                    self.rate_interval_count += 1;
+                    if self.rate_interval_count >= I5_RATE_MIN_SAMPLES {
+                        let mean_interval =
+                            self.rate_interval_sum_s / self.rate_interval_count as f64;
+                        let ratio = mean_interval / self.expected_hop_s;
+                        if !(1.0 / I5_RATE_TOLERANCE_FACTOR..=I5_RATE_TOLERANCE_FACTOR)
+                            .contains(&ratio)
+                        {
+                            return Some(SoakViolation {
+                                source: "rate",
+                                class: "wrong-rate",
+                                detail: format!(
+                                    "LF band update rate wrong at t={:.3}s: mean interval \
+                                     between changes {mean_interval:.3}s over {} samples vs. \
+                                     expected hop {:.3}s (ratio {ratio:.2}x, tolerance \
+                                     {I5_RATE_TOLERANCE_FACTOR}x either way) — still updating, \
+                                     just not at the right cadence",
+                                    sf.elapsed_s, self.rate_interval_count, self.expected_hop_s,
+                                ),
+                            });
+                        }
+                    }
+                }
+            } else {
+                let stale_for = sf.elapsed_s - self.last_change_elapsed_s;
+                let bound = self.liveness_hop_multiple * self.expected_hop_s;
+                if stale_for > bound {
+                    return Some(SoakViolation {
+                        source: "liveness",
+                        class: "frozen",
+                        detail: format!(
+                            "LF band unchanged for {stale_for:.3}s (> {bound:.3}s = \
+                             {}x expected hop {:.3}s) as of t={:.3}s",
+                            self.liveness_hop_multiple, self.expected_hop_s, sf.elapsed_s
+                        ),
+                    });
+                }
+            }
+
+            // I5b plausibility: LF band mean within tolerance of its own
+            // post-settle baseline (the "known level" — the injected
+            // noise's actual spectral-magnitude relationship isn't a
+            // closed form independent of window/aggregation, so the
+            // baseline is measured from this same run rather than
+            // assumed; a bug that garbles/collapses/drifts the LF band
+            // shows up as a departure from that self-measured reference
+            // just the same). Uses a rolling-window majority vote, not a
+            // strict consecutive streak: a band that keeps updating with
+            // wrong information doesn't necessarily stay out of tolerance
+            // on every single frame — an oscillating or partially-correct
+            // readout can dip back into tolerance between bad samples,
+            // which would reset a strict streak to zero and never fire.
+            if sf.elapsed_s >= self.settle_s {
+                self.checked_plausibility = true;
+                let cur = power_mean_db(lf);
+                match self.baseline_mean_db {
+                    None => {
+                        self.baseline_samples.push(cur);
+                        if self.baseline_samples.len() >= I5_BASELINE_FRAMES {
+                            let mean = self.baseline_samples.iter().sum::<f64>()
+                                / self.baseline_samples.len() as f64;
+                            self.baseline_mean_db = Some(mean);
+                        }
+                    }
+                    Some(baseline) => {
+                        let err = (cur - baseline).abs();
+                        let out_of_tolerance = err > self.plausibility_tol_db;
+                        self.plausibility_window.push_back(out_of_tolerance);
+                        while self.plausibility_window.len() > I5_PLAUSIBILITY_WINDOW {
+                            self.plausibility_window.pop_front();
+                        }
+                        let violations_in_window =
+                            self.plausibility_window.iter().filter(|&&v| v).count();
+                        if self.plausibility_window.len() >= I5_PLAUSIBILITY_WINDOW
+                            && violations_in_window >= I5_PLAUSIBILITY_WINDOW_MIN_VIOLATIONS
+                        {
+                            return Some(SoakViolation {
+                                source: "plausibility",
+                                class: "drift",
+                                detail: format!(
+                                    "LF band mean {cur:.2} dBFS at t={:.3}s departs from \
+                                     post-settle baseline {baseline:.2} dBFS by {err:.2} dB \
+                                     (tol {} dB) — {violations_in_window}/{} recent frames out \
+                                     of tolerance",
+                                    sf.elapsed_s,
+                                    self.plausibility_tol_db,
+                                    self.plausibility_window.len(),
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Dump frames N-1, N, N+1 (whatever is available) as CSVs alongside the
+/// elapsed-time-to-violation, per handoff.md's "this artifact is the
+/// debugging input for the fix issue" requirement. Returns the directory
+/// written, logged by the caller.
+fn dump_soak_violation(
+    frames: &std::collections::VecDeque<SoakFrame>,
+    violation: &SoakViolation,
+) -> std::io::Result<std::path::PathBuf> {
+    let base = std::env::var("AC_I5_DUMP_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir().join("ac-i5-soak-dump"));
+    let dir = base.join(format!("run-{}", std::process::id()));
+    std::fs::create_dir_all(&dir)?;
+
+    for (i, f) in frames.iter().enumerate() {
+        let path = dir.join(format!("frame_{i}_t{:.3}s.csv", f.elapsed_s));
+        let mut body = String::new();
+        body.push_str(&format!("# elapsed_s={:.6}\n", f.elapsed_s));
+        body.push_str(&format!("# daemon_ts_ns={}\n", f.ts_ns));
+        body.push_str(&format!("# violation_class={}\n", violation.class));
+        body.push_str(&format!("# violation_detail={}\n", violation.detail));
+        body.push_str("freq_hz,dbfs\n");
+        for (freq, db) in f.freqs.iter().zip(f.spectrum.iter()) {
+            body.push_str(&format!("{freq},{db}\n"));
+        }
+        std::fs::write(&path, body)?;
+    }
+    Ok(dir)
+}
+
+/// Every-published-frame soak: seeded broadband noise run long enough to
+/// exceed every internal buffer period (LF window, LF recompute hop, ring
+/// capacity) with margin, asserting I4-t/I2-t/I5a/I5b on each frame as it
+/// arrives. On the first violation, dumps N-1/N/N+1 and stops early
+/// (still reports elapsed time run); otherwise runs the full floor
+/// duration and reports each check green.
+fn run_i5_soak(
+    checks: &mut Vec<Check>,
+    ctrl: &CtrlClient,
+    store: &mut ChannelStore,
+    cfg: &DisplayConfig,
+    gpu: Option<&HeadlessGpu>,
+) -> anyhow::Result<()> {
+    let _ = ctrl.send(&json!({"cmd": "stop"}));
+    std::thread::sleep(Duration::from_millis(200));
+    let ack = ctrl.send(&json!({
+        "cmd": "monitor_spectrum",
+        "channels": [0],
+        "fft_n": HARNESS_FFT_N,
+        "fake_noise_dbfs": I5_NOISE_DBFS,
+    }))?;
+    if ack.get("ok").and_then(Value::as_bool) != Some(true) {
+        anyhow::bail!("I5 soak: monitor_spectrum ack not ok: {ack}");
+    }
+    // Derived from the daemon's own ack, not hardcoded, so a future
+    // config change (e.g. a larger lf_fft_n) is picked up automatically.
+    let lf_fft_n = ack
+        .get("lf_fft_n")
+        .and_then(Value::as_f64)
+        .unwrap_or(65536.0);
+    let crossover_hz = ack
+        .get("crossover_hz")
+        .and_then(Value::as_f64)
+        .unwrap_or(750.0);
+    let lf_overlap_pct = ack
+        .get("lf_overlap_pct")
+        .and_then(Value::as_f64)
+        .unwrap_or(90.0);
+    let lf_avg_tau_ms = ack
+        .get("lf_avg_tau_ms")
+        .and_then(Value::as_f64)
+        .unwrap_or(250.0);
+
+    let poll_start = Instant::now();
+    let init_deadline = poll_start + Duration::from_secs(10);
+    let sr: f64;
+    loop {
+        if Instant::now() > init_deadline {
+            anyhow::bail!("I5 soak: no initial frame within 10s");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+        if let Some(Some(f)) = store.read_all(cfg).into_iter().next() {
+            if !f.spectrum.is_empty() {
+                sr = f.meta.sr as f64;
+                break;
+            }
+        }
+    }
+
+    let lf_window_s = lf_fft_n / sr;
+    let expected_hop_s = lf_window_s * (1.0 - lf_overlap_pct / 100.0);
+    let tau_s = lf_avg_tau_ms / 1000.0;
+    let settle_s = (5.0 * tau_s).max(3.0 * expected_hop_s);
+    let floor_s = I5_SOAK_MIN_FLOOR_S.max(I5_SOAK_WINDOW_MARGIN * lf_window_s);
+
+    checks.push(Check {
+        name: "I5 soak config".to_string(),
+        pass: true,
+        detail: format!(
+            "sr={sr:.0}Hz lf_fft_n={lf_fft_n:.0} (window {lf_window_s:.3}s) \
+             lf_overlap={lf_overlap_pct:.0}% (expected hop {expected_hop_s:.3}s) \
+             lf_avg_tau={tau_s:.3}s crossover={crossover_hz:.0}Hz floor={floor_s:.1}s \
+             settle={settle_s:.2}s noise={I5_NOISE_DBFS}dBFS (deterministic per-channel \
+             LCG seed, see FakeEngine::noise_state — same seed replays identically)"
+        ),
+    });
+
+    let mut state = SoakState::new(crossover_hz, expected_hop_s, settle_s);
+    let mut ring: std::collections::VecDeque<SoakFrame> =
+        std::collections::VecDeque::with_capacity(3);
+    let mut violation: Option<SoakViolation> = None;
+    let mut extra_needed: u32 = 0;
+    let mut frame_count: usize = 0;
+    let mut last_t3_sample_s = -10.0;
+    let mut t3_worst_err_px: f32 = 0.0;
+    let mut t3_samples: u32 = 0;
+    let mut t3_failed = false;
+
+    loop {
+        let elapsed = poll_start.elapsed().as_secs_f64();
+        if violation.is_some() && extra_needed == 0 {
+            break;
+        }
+        if violation.is_none() && elapsed > floor_s {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(I5_POLL_INTERVAL_MS));
+        let Some(Some(f)) = store.read_all(cfg).into_iter().next() else {
+            continue;
+        };
+        if f.new_row.is_none() || f.spectrum.is_empty() {
+            continue;
+        }
+        let ts_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+        let sf = SoakFrame {
+            elapsed_s: elapsed,
+            ts_ns,
+            freqs: f.freqs.clone(),
+            spectrum: f.spectrum.clone(),
+        };
+        frame_count += 1;
+        ring.push_back(sf.clone());
+        while ring.len() > 3 {
+            ring.pop_front();
+        }
+
+        if violation.is_none() {
+            if let Some(v) = state.check_frame(&sf) {
+                violation = Some(v);
+                extra_needed = 1; // still want frame N+1 for the dump
+            }
+        } else {
+            extra_needed = extra_needed.saturating_sub(1);
+        }
+
+        // T3: sample the real paint path periodically, best-effort — a
+        // missing adapter must not fail the (GPU-independent) T2 soak
+        // above it. Compares the rendered pixel row at a fixed, safely
+        // mid-band LF column against the *buffer's own* reported value
+        // for that same column (not an assumed absolute level) — this is
+        // what "pixels track the buffer over time" means.
+        //
+        // Uses SpectrumEmber, not the plain Spectrum view: on real GPU
+        // hardware (RADV, not lavapipe) `render_spectrum_pixels`'s I1/I3
+        // checks independently fail (`find_trace_row` locks onto a row-0
+        // border/gridline artifact rather than the data trace — a
+        // pre-existing bug in that renderer's T3 path, unrelated to LF
+        // temporal averaging, reproduced by the existing non-soak I1/I3
+        // checks above and out of scope for this handoff). SpectrumEmber
+        // renders correctly on the same hardware, so it's the reliable
+        // choice for the soak's own T3 signal.
+        //
+        // Sampled every `I5_T3_SAMPLE_PERIOD_S` (looser than 1 Hz) because
+        // each sample re-settles the phosphor substrate
+        // (`render_ember_pixels`'s ~90-tick warm-up) — periodic per the
+        // handoff's own wording ("e.g., 1 Hz"), not a hard requirement.
+        if let Some(gpu) = gpu {
+            if elapsed - last_t3_sample_s >= I5_T3_SAMPLE_PERIOD_S {
+                last_t3_sample_s = elapsed;
+                if let Some((_, buf_db)) = nearest_dbfs(&f, I5_T3_SAMPLE_FREQ_HZ) {
+                    let pixels = render_ember_pixels(gpu, &f);
+                    let col = freq_to_col(I5_T3_SAMPLE_FREQ_HZ);
+                    match find_trace_row(&pixels, T3_WIDTH, T3_HEIGHT, col, [0, 0, 0]) {
+                        Some(row) => {
+                            let expected = expected_row_for_db(buf_db);
+                            let err = (row as f32 - expected).abs();
+                            t3_worst_err_px = t3_worst_err_px.max(err);
+                            t3_samples += 1;
+                        }
+                        None => t3_failed = true,
+                    }
+                }
+            }
+        }
+    }
+
+    let elapsed_total = poll_start.elapsed().as_secs_f64();
+
+    if let Some(v) = &violation {
+        let dump_dir = dump_soak_violation(&ring, v);
+        let dump_detail = match &dump_dir {
+            Ok(dir) => format!("dumped frames N-1/N/N+1 to {}", dir.display()),
+            Err(e) => format!("violation frame dump FAILED: {e}"),
+        };
+        checks.push(Check {
+            name: "I5 soak — first violation".to_string(),
+            pass: false,
+            detail: format!(
+                "class={} time-to-first-violation={:.3}s frames_observed={frame_count} — {} \
+                 — {dump_detail}",
+                v.class, elapsed_total, v.detail
+            ),
+        });
+    }
+
+    let early_stop_note = |name: &str, exercised: bool| -> String {
+        if violation.is_some() {
+            if exercised {
+                format!(
+                    "{name}: no violation seen before soak stopped early at t={elapsed_total:.3}s \
+                     ({frame_count} frames) — see 'I5 soak — first violation' for what did trip"
+                )
+            } else {
+                format!(
+                    "{name}: never exercised — soak stopped at t={elapsed_total:.3}s before this \
+                     check had enough state to run"
+                )
+            }
+        } else {
+            format!(
+                "{name}: no violation across full soak, t={elapsed_total:.3}s, \
+                 {frame_count} published frames observed"
+            )
+        }
+    };
+
+    checks.push(Check {
+        name: "I4-t bounded output (soak, every frame)".to_string(),
+        pass: violation.as_ref().is_none_or(|v| v.source != "bounded"),
+        detail: early_stop_note("I4-t bounded", state.checked_bounded),
+    });
+    checks.push(Check {
+        name: "I2-t continuity (soak, every frame)".to_string(),
+        pass: violation.as_ref().is_none_or(|v| v.source != "continuity"),
+        detail: early_stop_note("I2-t continuity", state.checked_continuity),
+    });
+    checks.push(Check {
+        name: "I5a LF liveness".to_string(),
+        pass: violation.as_ref().is_none_or(|v| v.source != "liveness"),
+        detail: early_stop_note("I5a LF liveness", state.checked_liveness),
+    });
+    checks.push(Check {
+        name: "I5b LF plausibility".to_string(),
+        pass: violation
+            .as_ref()
+            .is_none_or(|v| v.source != "plausibility"),
+        detail: early_stop_note("I5b LF plausibility", state.checked_plausibility),
+    });
+    checks.push(Check {
+        name: "I5c LF update rate".to_string(),
+        pass: violation.as_ref().is_none_or(|v| v.source != "rate"),
+        detail: early_stop_note("I5c LF update rate", state.checked_rate),
+    });
+
+    // Gated only on an outright failure to locate any trace at all (a
+    // render/crash-adjacent problem T3's other checks already cover) —
+    // not on pixel-position precision. Unlike the clean two-tone T1/T3
+    // captures above, a continuously-varying broadband-noise column
+    // spreads the ember phosphor's brightest-deviation pixel across
+    // several rows (blur from a genuinely busy, ever-changing trace, not
+    // an isolated apex), so a tight px tolerance here would flag harmless
+    // blur, not a regression. Reported for visibility per the same
+    // "reported, not asserted" precedent as `check_i2_variance_report`.
+    checks.push(Check {
+        name: format!("I5 soak T3 sampling (every {I5_T3_SAMPLE_PERIOD_S:.0}s, SpectrumEmber)"),
+        pass: !t3_failed,
+        detail: if gpu.is_none() {
+            "skipped — no wgpu adapter available (see 'T3 GPU adapter' check above)".to_string()
+        } else {
+            format!(
+                "{t3_samples} samples @ {I5_T3_SAMPLE_FREQ_HZ:.0}Hz, worst pixel drift from \
+                 buffer {t3_worst_err_px:.2}px (reported, not asserted — see rationale above), \
+                 failed_to_locate_trace={t3_failed}"
+            )
+        },
+    });
+
     Ok(())
 }
 
@@ -987,5 +1679,169 @@ mod tests {
             }
         }
         max
+    }
+
+    // ── I5 soak self-test (handoff.md acceptance criterion) ──
+    //
+    // "A deliberately introduced delayed-onset fault ... is caught by I5
+    // and NOT by I1-I4" — exercised here as a pure unit test against
+    // `SoakState` directly (no daemon, no GPU), the same style as the
+    // T3 self-tests above. Builds a synthetic run where the LF band
+    // behaves correctly for a while (varies frame to frame, like real
+    // noise-driven content) and then freezes solid — a ring-wrap /
+    // state-poisoning class of bug with onset delay, structurally
+    // invisible to a single-frame snapshot check.
+
+    fn synthetic_soak_frame(elapsed_s: f64, lf: &[f32], hf: &[f32]) -> SoakFrame {
+        let mut freqs = Vec::new();
+        let mut spectrum = Vec::new();
+        for (i, &v) in lf.iter().enumerate() {
+            freqs.push(100.0 + i as f32 * 100.0); // 100..700 Hz, below crossover
+            spectrum.push(v);
+        }
+        for (i, &v) in hf.iter().enumerate() {
+            freqs.push(800.0 + i as f32 * 100.0); // 800..1400 Hz, above crossover
+            spectrum.push(v);
+        }
+        SoakFrame {
+            elapsed_s,
+            ts_ns: (elapsed_s * 1e9) as u64,
+            freqs: Arc::new(freqs),
+            spectrum: Arc::new(spectrum),
+        }
+    }
+
+    #[test]
+    fn self_test_delayed_onset_freeze_caught_by_i5_not_by_a_snapshot_check() {
+        const CROSSOVER_HZ: f64 = 750.0;
+        const EXPECTED_HOP_S: f64 = 0.137;
+        const DT_S: f64 = 0.05;
+        const FREEZE_AT_FRAME: usize = 10;
+        const TOTAL_FRAMES: usize = 30;
+
+        // Close to the LF baseline so the LF/HF splice step (I2-t) never
+        // trips — this test isolates the liveness (I5a) invariant.
+        let hf = vec![-40.0f32; 7];
+        let mut state = SoakState::new(CROSSOVER_HZ, EXPECTED_HOP_S, /* settle_s */ 1000.0);
+        let mut frozen_lf: Option<Vec<f32>> = None;
+        let mut violation_frame: Option<(usize, SoakViolation)> = None;
+        let mut last_frame: Option<SoakFrame> = None;
+
+        for i in 0..TOTAL_FRAMES {
+            let elapsed = i as f64 * DT_S;
+            let lf: Vec<f32> = if i < FREEZE_AT_FRAME {
+                // Varies frame to frame, like real noise-driven LF content.
+                (0..7)
+                    .map(|k| -40.0 + (i as f32 * 0.7 + k as f32).sin() * 3.0)
+                    .collect()
+            } else {
+                // Ring-wrap / state-poisoning stand-in: identical to
+                // whatever the last pre-freeze frame was, forever after.
+                frozen_lf
+                    .get_or_insert_with(|| {
+                        (0..7)
+                            .map(|k| {
+                                -40.0 + ((FREEZE_AT_FRAME - 1) as f32 * 0.7 + k as f32).sin() * 3.0
+                            })
+                            .collect()
+                    })
+                    .clone()
+            };
+            let sf = synthetic_soak_frame(elapsed, &lf, &hf);
+            if violation_frame.is_none() {
+                if let Some(v) = state.check_frame(&sf) {
+                    violation_frame = Some((i, v));
+                }
+            }
+            last_frame = Some(sf);
+        }
+
+        let (frame_idx, violation) = violation_frame
+            .unwrap_or_else(|| panic!("I5 should have caught the delayed-onset freeze"));
+        assert_eq!(violation.source, "liveness");
+        assert_eq!(violation.class, "frozen");
+        // Must not fire before the freeze actually starts, and must fire
+        // with real delay (this is the "onset delay" I1-I4 can't see) —
+        // not on the very first post-freeze frame either, since a single
+        // stale reading is expected while the ring is still draining the
+        // last good hop.
+        assert!(
+            frame_idx > FREEZE_AT_FRAME,
+            "violation at frame {frame_idx} fired suspiciously early (freeze starts at \
+             frame {FREEZE_AT_FRAME})"
+        );
+
+        // The I1/I4-style snapshot check: one frame, judged in isolation.
+        // The last (frozen) frame's values are individually finite and
+        // bounded — there is nothing in a single frame that reveals the
+        // freeze, which is exactly why I1-I4 passed on the real bug this
+        // harness was built to catch (handoff.md).
+        let last = last_frame.unwrap();
+        let snapshot_looks_fine = last
+            .spectrum
+            .iter()
+            .all(|&v| v.is_finite() && v as f64 <= I4_TOLERANCE_DB);
+        assert!(
+            snapshot_looks_fine,
+            "sanity: the frozen frame must look individually valid to a snapshot check — \
+             otherwise this isn't testing what I5 adds over I1-I4"
+        );
+    }
+
+    /// Field feedback on this harness: the real bug doesn't necessarily
+    /// freeze — it can "continue to update with wrong rate ... and wrong
+    /// information as well." That pattern is invisible to I5a (which only
+    /// fires when the LF band *stops* changing) and could slip past a
+    /// naive per-frame plausibility check too if the wrong values
+    /// oscillate rather than sitting still. Builds a synthetic run where
+    /// the LF band changes on every single frame (never frozen) at ~7x
+    /// the expected hop rate, and where the post-settle values are
+    /// consistently offset from the pre-settle baseline — proving I5c
+    /// (rate) and I5b (plausibility) catch it while confirming I5a would
+    /// not have (the violation source must not be "liveness").
+    #[test]
+    fn self_test_updating_but_wrong_rate_and_wrong_info_not_caught_by_liveness_alone() {
+        const CROSSOVER_HZ: f64 = 750.0;
+        const EXPECTED_HOP_S: f64 = 0.137;
+        const DT_S: f64 = 0.02; // ~7x faster than the expected hop
+        const SETTLE_S: f64 = 1.0;
+        const TOTAL_FRAMES: usize = 200;
+
+        let mut state = SoakState::new(CROSSOVER_HZ, EXPECTED_HOP_S, SETTLE_S);
+        let mut violation: Option<SoakViolation> = None;
+
+        for i in 0..TOTAL_FRAMES {
+            let elapsed = i as f64 * DT_S;
+            // Before settle: correct-ish level, jittering normally.
+            // After settle: "wrong information" — offset hard from the
+            // pre-settle baseline, but still changing every frame (never
+            // frozen), and always at DT_S cadence (the wrong rate). HF
+            // tracks the same base as LF throughout so I2-t continuity
+            // (a different invariant) never trips — this test isolates
+            // I5c/I5b.
+            let base = if elapsed < SETTLE_S { -40.0 } else { -15.0 };
+            let hf = vec![base; 7];
+            let lf: Vec<f32> = (0..7)
+                .map(|k| base + (i as f32 * 1.3 + k as f32).sin() * 2.0)
+                .collect();
+            let sf = synthetic_soak_frame(elapsed, &lf, &hf);
+            if violation.is_none() {
+                violation = state.check_frame(&sf);
+            }
+        }
+
+        let violation = violation
+            .unwrap_or_else(|| panic!("I5 should have caught the wrong-rate/wrong-info run"));
+        assert_ne!(
+            violation.source, "liveness",
+            "I5a (frozen-only) must not be the one catching this — the band never stopped \
+             changing, which is exactly the gap this test guards against"
+        );
+        assert!(
+            violation.source == "rate" || violation.source == "plausibility",
+            "expected I5c (rate) or I5b (plausibility) to catch it, got source={:?}: {}",
+            violation.source,
+            violation.detail
+        );
     }
 }


### PR DESCRIPTION
Snapshot checks (I1-I4) settle, read one frame, judge — structurally blind to any bug with onset delay (ring-buffer wrap, EMA/state poisoning, cadence-boundary mishandling, or a band that keeps updating at the wrong rate with wrong values). Adds an I5 soak to `ac-ui --headless-test` that runs seeded broadband noise for a duration derived from the daemon's own reported LF window/hop/tau (not hardcoded) and asserts bounded (I4-t), LF/HF splice continuity (I2-t), liveness (I5a, frozen beyond 2x expected hop), plausibility (I5b, rolling-window vs. self-measured baseline — not a strict consecutive streak, so intermittent wrong values can't reset it to zero), and update rate (I5c, mean inter-change interval vs. expected hop, in either direction) on every published frame. First violation dumps frames N-1/N/N+1 as CSVs with elapsed-time-to-violation.

Found and fixed along the way: FakeEngine's broadband-noise generator reseeded its LCG to the same fixed state on every capture call, so a ring buffer fed only identical repeated blocks went periodic once fully wrapped — a real, structurally-invisible-to-snapshot-tests bug in the harness's own stimulus. State now persists per channel across calls (still deterministic/replayable from a fresh engine).

Self-tests prove the gap I1-I4 leave: a delayed-onset freeze, and separately content that keeps changing every frame but at the wrong rate with wrong information — neither caught by a single-frame snapshot or by liveness alone.

Amends .agents/qa.md: value-display and daemon-pipeline PRs now require I5 green in addition to I1-I4.

Validated locally and on real GPU (RADV) hardware with fake-audio only; two pre-existing, unrelated failures independently confirmed on a clean main checkout (Spectrum-view T3 pixel check, I1 buffer at the interp/aggregation crossover) — out of scope for this change.